### PR TITLE
[非开箱即用，需跟进开发]]加入蘑菇云/核爆以及瞬间白屏燃烧和耳鸣特效,并加入主要的GeckoLib类与函数。(包括自开发及搬运) 

### DIFF
--- a/src/main/java/com/hbm/init/BigExplosivesModBlockEntities.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModBlockEntities.java
@@ -1,0 +1,32 @@
+package net.mcreator.nuclearcraft.init;
+
+import com.mojang.datafixers.types.Type;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.block.entity.AdvancedWorkBenchBlockEntity;
+import net.mcreator.nuclearcraft.block.entity.BasicWorkBenchBlockEntity;
+import net.mcreator.nuclearcraft.block.entity.BasicWorkBenchGeckolibTileEntity;
+import net.mcreator.nuclearcraft.block.entity.GeckoAdvancedWorkbenchTileEntity;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModBlockEntities.class */
+public class BigExplosivesModBlockEntities {
+    public static final DeferredRegister<BlockEntityType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, BigExplosivesMod.MODID);
+    public static final RegistryObject<BlockEntityType<?>> BASIC_WORK_BENCH = register("basic_work_bench", BigExplosivesModBlocks.BASIC_WORK_BENCH, BasicWorkBenchBlockEntity::new);
+    public static final RegistryObject<BlockEntityType<?>> ADVANCED_WORK_BENCH = register("advanced_work_bench", BigExplosivesModBlocks.ADVANCED_WORK_BENCH, AdvancedWorkBenchBlockEntity::new);
+    public static final RegistryObject<BlockEntityType<BasicWorkBenchGeckolibTileEntity>> BASIC_WORK_BENCH_GECKOLIB = REGISTRY.register("basic_work_bench_geckolib", () -> {
+        return BlockEntityType.Builder.m_155273_(BasicWorkBenchGeckolibTileEntity::new, new Block[]{(Block) BigExplosivesModBlocks.BASIC_WORK_BENCH_GECKOLIB.get()}).m_58966_((Type) null);
+    });
+    public static final RegistryObject<BlockEntityType<GeckoAdvancedWorkbenchTileEntity>> GECKO_ADVANCED_WORKBENCH = REGISTRY.register("gecko_advanced_workbench", () -> {
+        return BlockEntityType.Builder.m_155273_(GeckoAdvancedWorkbenchTileEntity::new, new Block[]{(Block) BigExplosivesModBlocks.GECKO_ADVANCED_WORKBENCH.get()}).m_58966_((Type) null);
+    });
+
+    private static RegistryObject<BlockEntityType<?>> register(String registryname, RegistryObject<Block> block, BlockEntityType.BlockEntitySupplier<?> supplier) {
+        return REGISTRY.register(registryname, () -> {
+            return BlockEntityType.Builder.m_155273_(supplier, new Block[]{(Block) block.get()}).m_58966_((Type) null);
+        });
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModBlocks.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModBlocks.java
@@ -1,0 +1,28 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.block.AdvancedWorkBenchBlock;
+import net.mcreator.nuclearcraft.block.BasicWorkBenchBlock;
+import net.mcreator.nuclearcraft.block.BasicWorkBenchGeckolibBlock;
+import net.mcreator.nuclearcraft.block.GeckoAdvancedWorkbenchBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModBlocks.class */
+public class BigExplosivesModBlocks {
+    public static final DeferredRegister<Block> REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCKS, BigExplosivesMod.MODID);
+    public static final RegistryObject<Block> BASIC_WORK_BENCH = REGISTRY.register("basic_work_bench", () -> {
+        return new BasicWorkBenchBlock();
+    });
+    public static final RegistryObject<Block> ADVANCED_WORK_BENCH = REGISTRY.register("advanced_work_bench", () -> {
+        return new AdvancedWorkBenchBlock();
+    });
+    public static final RegistryObject<Block> BASIC_WORK_BENCH_GECKOLIB = REGISTRY.register("basic_work_bench_geckolib", () -> {
+        return new BasicWorkBenchGeckolibBlock();
+    });
+    public static final RegistryObject<Block> GECKO_ADVANCED_WORKBENCH = REGISTRY.register("gecko_advanced_workbench", () -> {
+        return new GeckoAdvancedWorkbenchBlock();
+    });
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModBrewingRecipes.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModBrewingRecipes.java
@@ -1,0 +1,30 @@
+package net.mcreator.nuclearcraft.init;
+
+import java.util.ArrayList;
+import java.util.List;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.RecipeTypes;
+import mezz.jei.api.recipe.vanilla.IJeiBrewingRecipe;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+@JeiPlugin
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModBrewingRecipes.class */
+public class BigExplosivesModBrewingRecipes implements IModPlugin {
+    public ResourceLocation getPluginUid() {
+        return new ResourceLocation("big_explosives:brewing_recipes");
+    }
+
+    public void registerRecipes(IRecipeRegistration registration) {
+        registration.getVanillaRecipeFactory();
+        List<IJeiBrewingRecipe> brewingRecipes = new ArrayList<>();
+        new ItemStack(Items.f_42589_);
+        new ItemStack(Items.f_42589_);
+        new ArrayList();
+        new ArrayList();
+        registration.addRecipes(RecipeTypes.BREWING, brewingRecipes);
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModEntities.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModEntities.java
@@ -1,0 +1,83 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.entity.AtomicBombEntity;
+import net.mcreator.nuclearcraft.entity.AtomicBombExplosionEntity;
+import net.mcreator.nuclearcraft.entity.BunkerBusterEntity;
+import net.mcreator.nuclearcraft.entity.CakeBombEntity;
+import net.mcreator.nuclearcraft.entity.FiveBombEntity;
+import net.mcreator.nuclearcraft.entity.FiveHundredKgExplosionEntity;
+import net.mcreator.nuclearcraft.entity.FourthOfJullyEntity;
+import net.mcreator.nuclearcraft.entity.NapalmBarraageEntity;
+import net.mcreator.nuclearcraft.entity.NapalmBombEntity;
+import net.mcreator.nuclearcraft.entity.TenKgBombAirstrikesEntity;
+import net.mcreator.nuclearcraft.entity.TwoFiddyEntity;
+import net.mcreator.nuclearcraft.entity.TwoHundredFiftyKgExplosionEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModEntities.class */
+public class BigExplosivesModEntities {
+    public static final DeferredRegister<EntityType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.ENTITY_TYPES, BigExplosivesMod.MODID);
+    public static final RegistryObject<EntityType<TwoFiddyEntity>> TWO_FIDDY = register("two_fiddy", EntityType.Builder.m_20704_(TwoFiddyEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(TwoFiddyEntity::new).m_20719_().m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<TwoHundredFiftyKgExplosionEntity>> TWO_HUNDRED_FIFTY_KG_EXPLOSION = register("two_hundred_fifty_kg_explosion", EntityType.Builder.m_20704_(TwoHundredFiftyKgExplosionEntity::new, MobCategory.MONSTER).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(TwoHundredFiftyKgExplosionEntity::new).m_20719_().m_20699_(1.0f, 1.0f));
+    public static final RegistryObject<EntityType<TenKgBombAirstrikesEntity>> TEN_KG_BOMB_AIRSTRIKES = register("ten_kg_bomb_airstrikes", EntityType.Builder.m_20704_(TenKgBombAirstrikesEntity::new, MobCategory.MONSTER).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(TenKgBombAirstrikesEntity::new).m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<FiveBombEntity>> FIVE_BOMB = register("five_bomb", EntityType.Builder.m_20704_(FiveBombEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(FiveBombEntity::new).m_20699_(1.0f, 1.5f));
+    public static final RegistryObject<EntityType<FiveHundredKgExplosionEntity>> FIVE_HUNDRED_KG_EXPLOSION = register("five_hundred_kg_explosion", EntityType.Builder.m_20704_(FiveHundredKgExplosionEntity::new, MobCategory.CREATURE).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(FiveHundredKgExplosionEntity::new).m_20719_().m_20699_(5.0f, 5.0f));
+    public static final RegistryObject<EntityType<NapalmBombEntity>> NAPALM_BOMB = register("napalm_bomb", EntityType.Builder.m_20704_(NapalmBombEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(NapalmBombEntity::new).m_20719_().m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<NapalmBarraageEntity>> NAPALM_BARRAAGE = register("napalm_barraage", EntityType.Builder.m_20704_(NapalmBarraageEntity::new, MobCategory.MONSTER).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(NapalmBarraageEntity::new).m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<BunkerBusterEntity>> BUNKER_BUSTER = register("bunker_buster", EntityType.Builder.m_20704_(BunkerBusterEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(BunkerBusterEntity::new).m_20719_().m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<AtomicBombEntity>> ATOMIC_BOMB = register("atomic_bomb", EntityType.Builder.m_20704_(AtomicBombEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(AtomicBombEntity::new).m_20699_(1.0f, 1.5f));
+    public static final RegistryObject<EntityType<AtomicBombExplosionEntity>> ATOMIC_BOMB_EXPLOSION = register("atomic_bomb_explosion", EntityType.Builder.m_20704_(AtomicBombExplosionEntity::new, MobCategory.CREATURE).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(AtomicBombExplosionEntity::new).m_20719_().m_20699_(60.0f, 60.0f));
+    public static final RegistryObject<EntityType<CakeBombEntity>> CAKE_BOMB = register("cake_bomb", EntityType.Builder.m_20704_(CakeBombEntity::new, MobCategory.MONSTER).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(CakeBombEntity::new).m_20699_(0.6f, 1.8f));
+    public static final RegistryObject<EntityType<FourthOfJullyEntity>> FOURTH_OF_JULLY = register("fourth_of_jully", EntityType.Builder.m_20704_(FourthOfJullyEntity::new, MobCategory.MISC).setShouldReceiveVelocityUpdates(true).setTrackingRange(64).setUpdateInterval(3).setCustomClientFactory(FourthOfJullyEntity::new).m_20719_().m_20699_(0.6f, 1.8f));
+
+    private static <T extends Entity> RegistryObject<EntityType<T>> register(String registryname, EntityType.Builder<T> entityTypeBuilder) {
+        return REGISTRY.register(registryname, () -> {
+            return entityTypeBuilder.m_20712_(registryname);
+        });
+    }
+
+    @SubscribeEvent
+    public static void init(FMLCommonSetupEvent event) {
+        event.enqueueWork(() -> {
+            TwoFiddyEntity.init();
+            TwoHundredFiftyKgExplosionEntity.init();
+            TenKgBombAirstrikesEntity.init();
+            FiveBombEntity.init();
+            FiveHundredKgExplosionEntity.init();
+            NapalmBombEntity.init();
+            NapalmBarraageEntity.init();
+            BunkerBusterEntity.init();
+            AtomicBombEntity.init();
+            AtomicBombExplosionEntity.init();
+            CakeBombEntity.init();
+            FourthOfJullyEntity.init();
+        });
+    }
+
+    @SubscribeEvent
+    public static void registerAttributes(EntityAttributeCreationEvent event) {
+        event.put((EntityType) TWO_FIDDY.get(), TwoFiddyEntity.createAttributes().m_22265_());
+        event.put((EntityType) TWO_HUNDRED_FIFTY_KG_EXPLOSION.get(), TwoHundredFiftyKgExplosionEntity.createAttributes().m_22265_());
+        event.put((EntityType) TEN_KG_BOMB_AIRSTRIKES.get(), TenKgBombAirstrikesEntity.createAttributes().m_22265_());
+        event.put((EntityType) FIVE_BOMB.get(), FiveBombEntity.createAttributes().m_22265_());
+        event.put((EntityType) FIVE_HUNDRED_KG_EXPLOSION.get(), FiveHundredKgExplosionEntity.createAttributes().m_22265_());
+        event.put((EntityType) NAPALM_BOMB.get(), NapalmBombEntity.createAttributes().m_22265_());
+        event.put((EntityType) NAPALM_BARRAAGE.get(), NapalmBarraageEntity.createAttributes().m_22265_());
+        event.put((EntityType) BUNKER_BUSTER.get(), BunkerBusterEntity.createAttributes().m_22265_());
+        event.put((EntityType) ATOMIC_BOMB.get(), AtomicBombEntity.createAttributes().m_22265_());
+        event.put((EntityType) ATOMIC_BOMB_EXPLOSION.get(), AtomicBombExplosionEntity.createAttributes().m_22265_());
+        event.put((EntityType) CAKE_BOMB.get(), CakeBombEntity.createAttributes().m_22265_());
+        event.put((EntityType) FOURTH_OF_JULLY.get(), FourthOfJullyEntity.createAttributes().m_22265_());
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModEntityRenderers.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModEntityRenderers.java
@@ -1,0 +1,39 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.client.renderer.AtomicBombExplosionRenderer;
+import net.mcreator.nuclearcraft.client.renderer.AtomicBombRenderer;
+import net.mcreator.nuclearcraft.client.renderer.BunkerBusterRenderer;
+import net.mcreator.nuclearcraft.client.renderer.CakeBombRenderer;
+import net.mcreator.nuclearcraft.client.renderer.FiveBombRenderer;
+import net.mcreator.nuclearcraft.client.renderer.FiveHundredKgExplosionRenderer;
+import net.mcreator.nuclearcraft.client.renderer.FourthOfJullyRenderer;
+import net.mcreator.nuclearcraft.client.renderer.NapalmBarraageRenderer;
+import net.mcreator.nuclearcraft.client.renderer.NapalmBombRenderer;
+import net.mcreator.nuclearcraft.client.renderer.TenKgBombAirstrikesRenderer;
+import net.mcreator.nuclearcraft.client.renderer.TwoFiddyRenderer;
+import net.mcreator.nuclearcraft.client.renderer.TwoHundredFiftyKgExplosionRenderer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT})
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModEntityRenderers.class */
+public class BigExplosivesModEntityRenderers {
+    @SubscribeEvent
+    public static void registerEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.TWO_FIDDY.get(), TwoFiddyRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.TWO_HUNDRED_FIFTY_KG_EXPLOSION.get(), TwoHundredFiftyKgExplosionRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.TEN_KG_BOMB_AIRSTRIKES.get(), TenKgBombAirstrikesRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.FIVE_BOMB.get(), FiveBombRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.FIVE_HUNDRED_KG_EXPLOSION.get(), FiveHundredKgExplosionRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.NAPALM_BOMB.get(), NapalmBombRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.NAPALM_BARRAAGE.get(), NapalmBarraageRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.BUNKER_BUSTER.get(), BunkerBusterRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.ATOMIC_BOMB.get(), AtomicBombRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.ATOMIC_BOMB_EXPLOSION.get(), AtomicBombExplosionRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.CAKE_BOMB.get(), CakeBombRenderer::new);
+        event.registerEntityRenderer((EntityType) BigExplosivesModEntities.FOURTH_OF_JULLY.get(), FourthOfJullyRenderer::new);
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModItems.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModItems.java
@@ -1,0 +1,130 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.block.display.BasicWorkBenchGeckolibDisplayItem;
+import net.mcreator.nuclearcraft.block.display.GeckoAdvancedWorkbenchDisplayItem;
+import net.mcreator.nuclearcraft.item.AtomBombItem;
+import net.mcreator.nuclearcraft.item.AtomicCoreItem;
+import net.mcreator.nuclearcraft.item.BunkerBusterBombItem;
+import net.mcreator.nuclearcraft.item.BunkerBusterDesignatorItem;
+import net.mcreator.nuclearcraft.item.CakeBombDesignatorItem;
+import net.mcreator.nuclearcraft.item.CoordStorerItem;
+import net.mcreator.nuclearcraft.item.EmptyAirstrikeDesignatorItem;
+import net.mcreator.nuclearcraft.item.ExplosiveCoreItem;
+import net.mcreator.nuclearcraft.item.FireCoreItem;
+import net.mcreator.nuclearcraft.item.FiveHundredKgBombDesignatorItem;
+import net.mcreator.nuclearcraft.item.FiveHundredKilogramBombItem;
+import net.mcreator.nuclearcraft.item.FourthOfJulyBombItem;
+import net.mcreator.nuclearcraft.item.FourthOfJulyDesignatorItem;
+import net.mcreator.nuclearcraft.item.GoldenBeetrootItem;
+import net.mcreator.nuclearcraft.item.GoldenBeetrootSoupItem;
+import net.mcreator.nuclearcraft.item.IronPlateItem;
+import net.mcreator.nuclearcraft.item.NapalmBarageDesignatorrItem;
+import net.mcreator.nuclearcraft.item.NapalmBombbItem;
+import net.mcreator.nuclearcraft.item.NapalmButtonItem;
+import net.mcreator.nuclearcraft.item.TenKgBombBarrageDesignatorItem;
+import net.mcreator.nuclearcraft.item.TenKgBombItem;
+import net.mcreator.nuclearcraft.item.TenKgNapalmBombItem;
+import net.mcreator.nuclearcraft.item.TestItem;
+import net.mcreator.nuclearcraft.item.TwoFiddyButtonItem;
+import net.mcreator.nuclearcraft.item.TwoHundredAndFiftyKgBombItem;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModItems.class */
+public class BigExplosivesModItems {
+    public static final DeferredRegister<Item> REGISTRY = DeferredRegister.create(ForgeRegistries.ITEMS, BigExplosivesMod.MODID);
+    public static final RegistryObject<Item> TWO_FIDDY_BUTTON = REGISTRY.register("two_fiddy_button", () -> {
+        return new TwoFiddyButtonItem();
+    });
+    public static final RegistryObject<Item> TWO_HUNDRED_AND_FIFTY_KG_BOMB = REGISTRY.register("two_hundred_and_fifty_kg_bomb", () -> {
+        return new TwoHundredAndFiftyKgBombItem();
+    });
+    public static final RegistryObject<Item> EMPTY_AIRSTRIKE_DESIGNATOR = REGISTRY.register("empty_airstrike_designator", () -> {
+        return new EmptyAirstrikeDesignatorItem();
+    });
+    public static final RegistryObject<Item> FIVE_HUNDRED_KILOGRAM_BOMB = REGISTRY.register("five_hundred_kilogram_bomb", () -> {
+        return new FiveHundredKilogramBombItem();
+    });
+    public static final RegistryObject<Item> TEN_KG_BOMB = REGISTRY.register("ten_kg_bomb", () -> {
+        return new TenKgBombItem();
+    });
+    public static final RegistryObject<Item> NAPALM_BUTTON = REGISTRY.register("napalm_button", () -> {
+        return new NapalmButtonItem();
+    });
+    public static final RegistryObject<Item> NAPALM_BOMBB = REGISTRY.register("napalm_bombb", () -> {
+        return new NapalmBombbItem();
+    });
+    public static final RegistryObject<Item> TEN_KG_NAPALM_BOMB = REGISTRY.register("ten_kg_napalm_bomb", () -> {
+        return new TenKgNapalmBombItem();
+    });
+    public static final RegistryObject<Item> BUNKER_BUSTER_BOMB = REGISTRY.register("bunker_buster_bomb", () -> {
+        return new BunkerBusterBombItem();
+    });
+    public static final RegistryObject<Item> BUNKER_BUSTER_DESIGNATOR = REGISTRY.register("bunker_buster_designator", () -> {
+        return new BunkerBusterDesignatorItem();
+    });
+    public static final RegistryObject<Item> ATOM_BOMB = REGISTRY.register("atom_bomb", () -> {
+        return new AtomBombItem();
+    });
+    public static final RegistryObject<Item> TEST = REGISTRY.register("test", () -> {
+        return new TestItem();
+    });
+    public static final RegistryObject<Item> FIVE_HUNDRED_KG_BOMB_DESIGNATOR = REGISTRY.register("five_hundred_kg_bomb_designator", () -> {
+        return new FiveHundredKgBombDesignatorItem();
+    });
+    public static final RegistryObject<Item> TEN_KG_BOMB_BARRAGE_DESIGNATOR = REGISTRY.register("ten_kg_bomb_barrage_designator", () -> {
+        return new TenKgBombBarrageDesignatorItem();
+    });
+    public static final RegistryObject<Item> NAPALM_BARAGE_DESIGNATORR = REGISTRY.register("napalm_barage_designatorr", () -> {
+        return new NapalmBarageDesignatorrItem();
+    });
+    public static final RegistryObject<Item> BASIC_WORK_BENCH = block(BigExplosivesModBlocks.BASIC_WORK_BENCH);
+    public static final RegistryObject<Item> ADVANCED_WORK_BENCH = block(BigExplosivesModBlocks.ADVANCED_WORK_BENCH);
+    public static final RegistryObject<Item> IRON_PLATE = REGISTRY.register("iron_plate", () -> {
+        return new IronPlateItem();
+    });
+    public static final RegistryObject<Item> ATOMIC_CORE = REGISTRY.register("atomic_core", () -> {
+        return new AtomicCoreItem();
+    });
+    public static final RegistryObject<Item> FIRE_CORE = REGISTRY.register("fire_core", () -> {
+        return new FireCoreItem();
+    });
+    public static final RegistryObject<Item> BASIC_WORK_BENCH_GECKOLIB = REGISTRY.register(BigExplosivesModBlocks.BASIC_WORK_BENCH_GECKOLIB.getId().m_135815_(), () -> {
+        return new BasicWorkBenchGeckolibDisplayItem((Block) BigExplosivesModBlocks.BASIC_WORK_BENCH_GECKOLIB.get(), new Item.Properties());
+    });
+    public static final RegistryObject<Item> GECKO_ADVANCED_WORKBENCH = REGISTRY.register(BigExplosivesModBlocks.GECKO_ADVANCED_WORKBENCH.getId().m_135815_(), () -> {
+        return new GeckoAdvancedWorkbenchDisplayItem((Block) BigExplosivesModBlocks.GECKO_ADVANCED_WORKBENCH.get(), new Item.Properties());
+    });
+    public static final RegistryObject<Item> EXPLOSIVE_CORE = REGISTRY.register("explosive_core", () -> {
+        return new ExplosiveCoreItem();
+    });
+    public static final RegistryObject<Item> GOLDEN_BEETROOT = REGISTRY.register("golden_beetroot", () -> {
+        return new GoldenBeetrootItem();
+    });
+    public static final RegistryObject<Item> GOLDEN_BEETROOT_SOUP = REGISTRY.register("golden_beetroot_soup", () -> {
+        return new GoldenBeetrootSoupItem();
+    });
+    public static final RegistryObject<Item> CAKE_BOMB_DESIGNATOR = REGISTRY.register("cake_bomb_designator", () -> {
+        return new CakeBombDesignatorItem();
+    });
+    public static final RegistryObject<Item> COORD_STORER = REGISTRY.register("coord_storer", () -> {
+        return new CoordStorerItem();
+    });
+    public static final RegistryObject<Item> FOURTH_OF_JULY_DESIGNATOR = REGISTRY.register("fourth_of_july_designator", () -> {
+        return new FourthOfJulyDesignatorItem();
+    });
+    public static final RegistryObject<Item> FOURTH_OF_JULY_BOMB = REGISTRY.register("fourth_of_july_bomb", () -> {
+        return new FourthOfJulyBombItem();
+    });
+
+    private static RegistryObject<Item> block(RegistryObject<Block> block) {
+        return REGISTRY.register(block.getId().m_135815_(), () -> {
+            return new BlockItem((Block) block.get(), new Item.Properties());
+        });
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModMenus.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModMenus.java
@@ -1,0 +1,21 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.world.inventory.AdvancedWorkBechGuiMenu;
+import net.mcreator.nuclearcraft.world.inventory.BasicWorkBenchGuiMenu;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraftforge.common.extensions.IForgeMenuType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModMenus.class */
+public class BigExplosivesModMenus {
+    public static final DeferredRegister<MenuType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.MENU_TYPES, BigExplosivesMod.MODID);
+    public static final RegistryObject<MenuType<BasicWorkBenchGuiMenu>> BASIC_WORK_BENCH_GUI = REGISTRY.register("basic_work_bench_gui", () -> {
+        return IForgeMenuType.create(BasicWorkBenchGuiMenu::new);
+    });
+    public static final RegistryObject<MenuType<AdvancedWorkBechGuiMenu>> ADVANCED_WORK_BECH_GUI = REGISTRY.register("advanced_work_bech_gui", () -> {
+        return IForgeMenuType.create(AdvancedWorkBechGuiMenu::new);
+    });
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModMobEffects.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModMobEffects.java
@@ -1,0 +1,28 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.potion.RadiationImmunityMobEffect;
+import net.mcreator.nuclearcraft.potion.RadiationPoisoningMobEffect;
+import net.mcreator.nuclearcraft.potion.ScreenShakeEffectMobEffect;
+import net.mcreator.nuclearcraft.potion.WhiteOutEffectMobEffect;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModMobEffects.class */
+public class BigExplosivesModMobEffects {
+    public static final DeferredRegister<MobEffect> REGISTRY = DeferredRegister.create(ForgeRegistries.MOB_EFFECTS, BigExplosivesMod.MODID);
+    public static final RegistryObject<MobEffect> WHITE_OUT_EFFECT = REGISTRY.register("white_out_effect", () -> {
+        return new WhiteOutEffectMobEffect();
+    });
+    public static final RegistryObject<MobEffect> SCREEN_SHAKE_EFFECT = REGISTRY.register("screen_shake_effect", () -> {
+        return new ScreenShakeEffectMobEffect();
+    });
+    public static final RegistryObject<MobEffect> RADIATION_POISONING = REGISTRY.register("radiation_poisoning", () -> {
+        return new RadiationPoisoningMobEffect();
+    });
+    public static final RegistryObject<MobEffect> RADIATION_IMMUNITY = REGISTRY.register("radiation_immunity", () -> {
+        return new RadiationImmunityMobEffect();
+    });
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModParticleTypes.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModParticleTypes.java
@@ -1,0 +1,16 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.core.particles.ParticleType;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModParticleTypes.class */
+public class BigExplosivesModParticleTypes {
+    public static final DeferredRegister<ParticleType<?>> REGISTRY = DeferredRegister.create(ForgeRegistries.PARTICLE_TYPES, BigExplosivesMod.MODID);
+    public static final RegistryObject<SimpleParticleType> SMOKE = REGISTRY.register("smoke", () -> {
+        return new SimpleParticleType(false);
+    });
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModParticles.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModParticles.java
@@ -1,0 +1,17 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.client.particle.SmokeParticle;
+import net.minecraft.core.particles.ParticleType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT})
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModParticles.class */
+public class BigExplosivesModParticles {
+    @SubscribeEvent
+    public static void registerParticles(RegisterParticleProvidersEvent event) {
+        event.registerSpriteSet((ParticleType) BigExplosivesModParticleTypes.SMOKE.get(), SmokeParticle::provider);
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModScreens.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModScreens.java
@@ -1,0 +1,22 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.client.gui.AdvancedWorkBechGuiScreen;
+import net.mcreator.nuclearcraft.client.gui.BasicWorkBenchGuiScreen;
+import net.minecraft.client.gui.screens.MenuScreens;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, value = {Dist.CLIENT})
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModScreens.class */
+public class BigExplosivesModScreens {
+    @SubscribeEvent
+    public static void clientLoad(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> {
+            MenuScreens.m_96206_((MenuType) BigExplosivesModMenus.BASIC_WORK_BENCH_GUI.get(), BasicWorkBenchGuiScreen::new);
+            MenuScreens.m_96206_((MenuType) BigExplosivesModMenus.ADVANCED_WORK_BECH_GUI.get(), AdvancedWorkBechGuiScreen::new);
+        });
+    }
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModSounds.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModSounds.java
@@ -1,0 +1,76 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModSounds.class */
+public class BigExplosivesModSounds {
+    public static final DeferredRegister<SoundEvent> REGISTRY = DeferredRegister.create(ForgeRegistries.SOUND_EVENTS, BigExplosivesMod.MODID);
+    public static final RegistryObject<SoundEvent> DESIGNATORBEEP = REGISTRY.register("designatorbeep", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "designatorbeep"));
+    });
+    public static final RegistryObject<SoundEvent> BIG_BOMB = REGISTRY.register("big_bomb", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "big_bomb"));
+    });
+    public static final RegistryObject<SoundEvent> UNDERWATEREXPLODE = REGISTRY.register("underwaterexplode", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "underwaterexplode"));
+    });
+    public static final RegistryObject<SoundEvent> MEDIUM_BOMB = REGISTRY.register("medium_bomb", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "medium_bomb"));
+    });
+    public static final RegistryObject<SoundEvent> SMALL_BOMB = REGISTRY.register("small_bomb", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "small_bomb"));
+    });
+    public static final RegistryObject<SoundEvent> SMALLER_BOMB = REGISTRY.register("smaller_bomb", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "smaller_bomb"));
+    });
+    public static final RegistryObject<SoundEvent> BUNKERBUSTERDRILLSOUND = REGISTRY.register("bunkerbusterdrillsound", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "bunkerbusterdrillsound"));
+    });
+    public static final RegistryObject<SoundEvent> ATOMBOMBCLOSE = REGISTRY.register("atombombclose", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "atombombclose"));
+    });
+    public static final RegistryObject<SoundEvent> ATOMBOMBFAR = REGISTRY.register("atombombfar", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "atombombfar"));
+    });
+    public static final RegistryObject<SoundEvent> ATOMBOMBEXTREMELYFAR = REGISTRY.register("atombombextremelyfar", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "atombombextremelyfar"));
+    });
+    public static final RegistryObject<SoundEvent> EARRINGING = REGISTRY.register("earringing", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "earringing"));
+    });
+    public static final RegistryObject<SoundEvent> EAR_RINGINGSHORT = REGISTRY.register("ear-ringingshort", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "ear-ringingshort"));
+    });
+    public static final RegistryObject<SoundEvent> EARSHOT = REGISTRY.register("earshot", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "earshot"));
+    });
+    public static final RegistryObject<SoundEvent> BOOM = REGISTRY.register("boom", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "boom"));
+    });
+    public static final RegistryObject<SoundEvent> SUPERFAREXPLOSION = REGISTRY.register("superfarexplosion", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "superfarexplosion"));
+    });
+    public static final RegistryObject<SoundEvent> EATLIBERTY = REGISTRY.register("eatliberty", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "eatliberty"));
+    });
+    public static final RegistryObject<SoundEvent> HERECOMESTHECALVARY = REGISTRY.register("herecomesthecalvary", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "herecomesthecalvary"));
+    });
+    public static final RegistryObject<SoundEvent> COMMININHOY = REGISTRY.register("commininhoy", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "commininhoy"));
+    });
+    public static final RegistryObject<SoundEvent> DELIVERINGPAYLOAD = REGISTRY.register("deliveringpayload", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "deliveringpayload"));
+    });
+    public static final RegistryObject<SoundEvent> DEMOCRACYSONITSWAY = REGISTRY.register("democracysonitsway", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "democracysonitsway"));
+    });
+    public static final RegistryObject<SoundEvent> PARTYHORN = REGISTRY.register("partyhorn", () -> {
+        return SoundEvent.m_262824_(new ResourceLocation(BigExplosivesMod.MODID, "partyhorn"));
+    });
+}

--- a/src/main/java/com/hbm/init/BigExplosivesModTabs.java
+++ b/src/main/java/com/hbm/init/BigExplosivesModTabs.java
@@ -1,0 +1,48 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/BigExplosivesModTabs.class */
+public class BigExplosivesModTabs {
+    public static final DeferredRegister<CreativeModeTab> REGISTRY = DeferredRegister.create(Registries.f_279569_, BigExplosivesMod.MODID);
+    public static final RegistryObject<CreativeModeTab> EXPLOSIVES = REGISTRY.register("explosives", () -> {
+        return CreativeModeTab.builder().m_257941_(Component.m_237115_("item_group.big_explosives.explosives")).m_257737_(() -> {
+            return new ItemStack((ItemLike) BigExplosivesModItems.TWO_HUNDRED_AND_FIFTY_KG_BOMB.get());
+        }).m_257501_((parameters, tabData) -> {
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TWO_FIDDY_BUTTON.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TWO_HUNDRED_AND_FIFTY_KG_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.EMPTY_AIRSTRIKE_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.FIVE_HUNDRED_KILOGRAM_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TEN_KG_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.NAPALM_BUTTON.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.NAPALM_BOMBB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TEN_KG_NAPALM_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.BUNKER_BUSTER_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.BUNKER_BUSTER_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.ATOM_BOMB.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TEST.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.FIVE_HUNDRED_KG_BOMB_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.TEN_KG_BOMB_BARRAGE_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.NAPALM_BARAGE_DESIGNATORR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.IRON_PLATE.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.ATOMIC_CORE.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.FIRE_CORE.get());
+            tabData.m_246326_(((Block) BigExplosivesModBlocks.BASIC_WORK_BENCH_GECKOLIB.get()).m_5456_());
+            tabData.m_246326_(((Block) BigExplosivesModBlocks.GECKO_ADVANCED_WORKBENCH.get()).m_5456_());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.EXPLOSIVE_CORE.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.GOLDEN_BEETROOT.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.GOLDEN_BEETROOT_SOUP.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.CAKE_BOMB_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.FOURTH_OF_JULY_DESIGNATOR.get());
+            tabData.m_246326_((ItemLike) BigExplosivesModItems.FOURTH_OF_JULY_BOMB.get());
+        }).m_257652_();
+    });
+}

--- a/src/main/java/com/hbm/init/EntityAnimationFactory.java
+++ b/src/main/java/com/hbm/init/EntityAnimationFactory.java
@@ -1,0 +1,135 @@
+package net.mcreator.nuclearcraft.init;
+
+import net.mcreator.nuclearcraft.entity.AtomicBombEntity;
+import net.mcreator.nuclearcraft.entity.AtomicBombExplosionEntity;
+import net.mcreator.nuclearcraft.entity.BunkerBusterEntity;
+import net.mcreator.nuclearcraft.entity.CakeBombEntity;
+import net.mcreator.nuclearcraft.entity.FiveBombEntity;
+import net.mcreator.nuclearcraft.entity.FiveHundredKgExplosionEntity;
+import net.mcreator.nuclearcraft.entity.FourthOfJullyEntity;
+import net.mcreator.nuclearcraft.entity.NapalmBarraageEntity;
+import net.mcreator.nuclearcraft.entity.NapalmBombEntity;
+import net.mcreator.nuclearcraft.entity.TenKgBombAirstrikesEntity;
+import net.mcreator.nuclearcraft.entity.TwoFiddyEntity;
+import net.mcreator.nuclearcraft.entity.TwoHundredFiftyKgExplosionEntity;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/init/EntityAnimationFactory.class */
+public class EntityAnimationFactory {
+    @SubscribeEvent
+    public static void onEntityTick(LivingEvent.LivingTickEvent event) {
+        if (event != null && event.getEntity() != null) {
+            TwoFiddyEntity entity = event.getEntity();
+            if (entity instanceof TwoFiddyEntity) {
+                TwoFiddyEntity syncable = entity;
+                String animation = syncable.getSyncedAnimation();
+                if (!animation.equals("undefined")) {
+                    syncable.setAnimation("undefined");
+                    syncable.animationprocedure = animation;
+                }
+            }
+            TwoHundredFiftyKgExplosionEntity entity2 = event.getEntity();
+            if (entity2 instanceof TwoHundredFiftyKgExplosionEntity) {
+                TwoHundredFiftyKgExplosionEntity syncable2 = entity2;
+                String animation2 = syncable2.getSyncedAnimation();
+                if (!animation2.equals("undefined")) {
+                    syncable2.setAnimation("undefined");
+                    syncable2.animationprocedure = animation2;
+                }
+            }
+            TenKgBombAirstrikesEntity entity3 = event.getEntity();
+            if (entity3 instanceof TenKgBombAirstrikesEntity) {
+                TenKgBombAirstrikesEntity syncable3 = entity3;
+                String animation3 = syncable3.getSyncedAnimation();
+                if (!animation3.equals("undefined")) {
+                    syncable3.setAnimation("undefined");
+                    syncable3.animationprocedure = animation3;
+                }
+            }
+            FiveBombEntity entity4 = event.getEntity();
+            if (entity4 instanceof FiveBombEntity) {
+                FiveBombEntity syncable4 = entity4;
+                String animation4 = syncable4.getSyncedAnimation();
+                if (!animation4.equals("undefined")) {
+                    syncable4.setAnimation("undefined");
+                    syncable4.animationprocedure = animation4;
+                }
+            }
+            FiveHundredKgExplosionEntity entity5 = event.getEntity();
+            if (entity5 instanceof FiveHundredKgExplosionEntity) {
+                FiveHundredKgExplosionEntity syncable5 = entity5;
+                String animation5 = syncable5.getSyncedAnimation();
+                if (!animation5.equals("undefined")) {
+                    syncable5.setAnimation("undefined");
+                    syncable5.animationprocedure = animation5;
+                }
+            }
+            NapalmBombEntity entity6 = event.getEntity();
+            if (entity6 instanceof NapalmBombEntity) {
+                NapalmBombEntity syncable6 = entity6;
+                String animation6 = syncable6.getSyncedAnimation();
+                if (!animation6.equals("undefined")) {
+                    syncable6.setAnimation("undefined");
+                    syncable6.animationprocedure = animation6;
+                }
+            }
+            NapalmBarraageEntity entity7 = event.getEntity();
+            if (entity7 instanceof NapalmBarraageEntity) {
+                NapalmBarraageEntity syncable7 = entity7;
+                String animation7 = syncable7.getSyncedAnimation();
+                if (!animation7.equals("undefined")) {
+                    syncable7.setAnimation("undefined");
+                    syncable7.animationprocedure = animation7;
+                }
+            }
+            BunkerBusterEntity entity8 = event.getEntity();
+            if (entity8 instanceof BunkerBusterEntity) {
+                BunkerBusterEntity syncable8 = entity8;
+                String animation8 = syncable8.getSyncedAnimation();
+                if (!animation8.equals("undefined")) {
+                    syncable8.setAnimation("undefined");
+                    syncable8.animationprocedure = animation8;
+                }
+            }
+            AtomicBombEntity entity9 = event.getEntity();
+            if (entity9 instanceof AtomicBombEntity) {
+                AtomicBombEntity syncable9 = entity9;
+                String animation9 = syncable9.getSyncedAnimation();
+                if (!animation9.equals("undefined")) {
+                    syncable9.setAnimation("undefined");
+                    syncable9.animationprocedure = animation9;
+                }
+            }
+            AtomicBombExplosionEntity entity10 = event.getEntity();
+            if (entity10 instanceof AtomicBombExplosionEntity) {
+                AtomicBombExplosionEntity syncable10 = entity10;
+                String animation10 = syncable10.getSyncedAnimation();
+                if (!animation10.equals("undefined")) {
+                    syncable10.setAnimation("undefined");
+                    syncable10.animationprocedure = animation10;
+                }
+            }
+            CakeBombEntity entity11 = event.getEntity();
+            if (entity11 instanceof CakeBombEntity) {
+                CakeBombEntity syncable11 = entity11;
+                String animation11 = syncable11.getSyncedAnimation();
+                if (!animation11.equals("undefined")) {
+                    syncable11.setAnimation("undefined");
+                    syncable11.animationprocedure = animation11;
+                }
+            }
+            FourthOfJullyEntity entity12 = event.getEntity();
+            if (entity12 instanceof FourthOfJullyEntity) {
+                FourthOfJullyEntity syncable12 = entity12;
+                String animation12 = syncable12.getSyncedAnimation();
+                if (!animation12.equals("undefined")) {
+                    syncable12.setAnimation("undefined");
+                    syncable12.animationprocedure = animation12;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/network/AdvancedWorkBechGuiSlotMessage.java
+++ b/src/main/java/com/hbm/network/AdvancedWorkBechGuiSlotMessage.java
@@ -1,0 +1,82 @@
+package net.mcreator.nuclearcraft.network;
+
+import java.util.HashMap;
+import java.util.function.Supplier;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.procedures.ItemTakenFromAdvancedOutputProcedure;
+import net.mcreator.nuclearcraft.world.inventory.AdvancedWorkBechGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.network.NetworkEvent;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/AdvancedWorkBechGuiSlotMessage.class */
+public class AdvancedWorkBechGuiSlotMessage {
+    private final int slotID;
+    private final int x;
+    private final int y;
+    private final int z;
+    private final int changeType;
+    private final int meta;
+
+    public AdvancedWorkBechGuiSlotMessage(int slotID, int x, int y, int z, int changeType, int meta) {
+        this.slotID = slotID;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.changeType = changeType;
+        this.meta = meta;
+    }
+
+    public AdvancedWorkBechGuiSlotMessage(FriendlyByteBuf buffer) {
+        this.slotID = buffer.readInt();
+        this.x = buffer.readInt();
+        this.y = buffer.readInt();
+        this.z = buffer.readInt();
+        this.changeType = buffer.readInt();
+        this.meta = buffer.readInt();
+    }
+
+    public static void buffer(AdvancedWorkBechGuiSlotMessage message, FriendlyByteBuf buffer) {
+        buffer.writeInt(message.slotID);
+        buffer.writeInt(message.x);
+        buffer.writeInt(message.y);
+        buffer.writeInt(message.z);
+        buffer.writeInt(message.changeType);
+        buffer.writeInt(message.meta);
+    }
+
+    public static void handler(AdvancedWorkBechGuiSlotMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            ServerPlayer sender = context.getSender();
+            int slotID = message.slotID;
+            int changeType = message.changeType;
+            int meta = message.meta;
+            int x = message.x;
+            int y = message.y;
+            int z = message.z;
+            handleSlotAction(sender, slotID, changeType, meta, x, y, z);
+        });
+        context.setPacketHandled(true);
+    }
+
+    public static void handleSlotAction(Player entity, int slot, int changeType, int meta, int x, int y, int z) {
+        Level world = entity.m_9236_();
+        HashMap<String, Object> map = AdvancedWorkBechGuiMenu.guistate;
+        if (world.m_46805_(new BlockPos(x, y, z)) && slot == 16 && changeType == 1) {
+            ItemTakenFromAdvancedOutputProcedure.execute(entity);
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerMessage(FMLCommonSetupEvent event) {
+        BigExplosivesMod.addNetworkMessage(AdvancedWorkBechGuiSlotMessage.class, AdvancedWorkBechGuiSlotMessage::buffer, AdvancedWorkBechGuiSlotMessage::new, AdvancedWorkBechGuiSlotMessage::handler);
+    }
+}

--- a/src/main/java/com/hbm/network/BasicWorkBenchGuiSlotMessage.java
+++ b/src/main/java/com/hbm/network/BasicWorkBenchGuiSlotMessage.java
@@ -1,0 +1,82 @@
+package net.mcreator.nuclearcraft.network;
+
+import java.util.HashMap;
+import java.util.function.Supplier;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.procedures.ItemTakenFromBasicOutputSlotProcedure;
+import net.mcreator.nuclearcraft.world.inventory.BasicWorkBenchGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.network.NetworkEvent;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BasicWorkBenchGuiSlotMessage.class */
+public class BasicWorkBenchGuiSlotMessage {
+    private final int slotID;
+    private final int x;
+    private final int y;
+    private final int z;
+    private final int changeType;
+    private final int meta;
+
+    public BasicWorkBenchGuiSlotMessage(int slotID, int x, int y, int z, int changeType, int meta) {
+        this.slotID = slotID;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.changeType = changeType;
+        this.meta = meta;
+    }
+
+    public BasicWorkBenchGuiSlotMessage(FriendlyByteBuf buffer) {
+        this.slotID = buffer.readInt();
+        this.x = buffer.readInt();
+        this.y = buffer.readInt();
+        this.z = buffer.readInt();
+        this.changeType = buffer.readInt();
+        this.meta = buffer.readInt();
+    }
+
+    public static void buffer(BasicWorkBenchGuiSlotMessage message, FriendlyByteBuf buffer) {
+        buffer.writeInt(message.slotID);
+        buffer.writeInt(message.x);
+        buffer.writeInt(message.y);
+        buffer.writeInt(message.z);
+        buffer.writeInt(message.changeType);
+        buffer.writeInt(message.meta);
+    }
+
+    public static void handler(BasicWorkBenchGuiSlotMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            ServerPlayer sender = context.getSender();
+            int slotID = message.slotID;
+            int changeType = message.changeType;
+            int meta = message.meta;
+            int x = message.x;
+            int y = message.y;
+            int z = message.z;
+            handleSlotAction(sender, slotID, changeType, meta, x, y, z);
+        });
+        context.setPacketHandled(true);
+    }
+
+    public static void handleSlotAction(Player entity, int slot, int changeType, int meta, int x, int y, int z) {
+        Level world = entity.m_9236_();
+        HashMap<String, Object> map = BasicWorkBenchGuiMenu.guistate;
+        if (world.m_46805_(new BlockPos(x, y, z)) && slot == 7 && changeType == 1) {
+            ItemTakenFromBasicOutputSlotProcedure.execute(entity);
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerMessage(FMLCommonSetupEvent event) {
+        BigExplosivesMod.addNetworkMessage(BasicWorkBenchGuiSlotMessage.class, BasicWorkBenchGuiSlotMessage::buffer, BasicWorkBenchGuiSlotMessage::new, BasicWorkBenchGuiSlotMessage::handler);
+    }
+}

--- a/src/main/java/com/hbm/network/BigExplosivesModVariables.java
+++ b/src/main/java/com/hbm/network/BigExplosivesModVariables.java
@@ -1,0 +1,169 @@
+package net.mcreator.nuclearcraft.network;
+
+import java.util.function.Supplier;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BigExplosivesModVariables.class */
+public class BigExplosivesModVariables {
+    public static final Capability<PlayerVariables> PLAYER_VARIABLES_CAPABILITY = CapabilityManager.get(new CapabilityToken<PlayerVariables>() { // from class: net.mcreator.nuclearcraft.network.BigExplosivesModVariables.1
+    });
+
+    @SubscribeEvent
+    public static void init(FMLCommonSetupEvent event) {
+        BigExplosivesMod.addNetworkMessage(PlayerVariablesSyncMessage.class, PlayerVariablesSyncMessage::buffer, PlayerVariablesSyncMessage::new, PlayerVariablesSyncMessage::handler);
+    }
+
+    @SubscribeEvent
+    public static void init(RegisterCapabilitiesEvent event) {
+        event.register(PlayerVariables.class);
+    }
+
+    @Mod.EventBusSubscriber
+    /* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BigExplosivesModVariables$EventBusVariableHandlers.class */
+    public static class EventBusVariableHandlers {
+        @SubscribeEvent
+        public static void onPlayerLoggedInSyncPlayerVariables(PlayerEvent.PlayerLoggedInEvent event) {
+            if (!event.getEntity().m_9236_().m_5776_()) {
+                ((PlayerVariables) event.getEntity().getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables())).syncPlayerVariables(event.getEntity());
+            }
+        }
+
+        @SubscribeEvent
+        public static void onPlayerRespawnedSyncPlayerVariables(PlayerEvent.PlayerRespawnEvent event) {
+            if (!event.getEntity().m_9236_().m_5776_()) {
+                ((PlayerVariables) event.getEntity().getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables())).syncPlayerVariables(event.getEntity());
+            }
+        }
+
+        @SubscribeEvent
+        public static void onPlayerChangedDimensionSyncPlayerVariables(PlayerEvent.PlayerChangedDimensionEvent event) {
+            if (!event.getEntity().m_9236_().m_5776_()) {
+                ((PlayerVariables) event.getEntity().getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables())).syncPlayerVariables(event.getEntity());
+            }
+        }
+
+        @SubscribeEvent
+        public static void clonePlayer(PlayerEvent.Clone event) {
+            event.getOriginal().revive();
+            PlayerVariables original = (PlayerVariables) event.getOriginal().getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables());
+            PlayerVariables clone = (PlayerVariables) event.getEntity().getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables());
+            clone.fadevariable = original.fadevariable;
+            clone.ScreenShake = original.ScreenShake;
+            if (!event.isWasDeath()) {
+            }
+        }
+    }
+
+    @Mod.EventBusSubscriber
+    /* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BigExplosivesModVariables$PlayerVariablesProvider.class */
+    private static class PlayerVariablesProvider implements ICapabilitySerializable<Tag> {
+        private final PlayerVariables playerVariables = new PlayerVariables();
+        private final LazyOptional<PlayerVariables> instance = LazyOptional.of(() -> {
+            return this.playerVariables;
+        });
+
+        private PlayerVariablesProvider() {
+        }
+
+        @SubscribeEvent
+        public static void onAttachCapabilities(AttachCapabilitiesEvent<Entity> event) {
+            if ((event.getObject() instanceof Player) && !(event.getObject() instanceof FakePlayer)) {
+                event.addCapability(new ResourceLocation(BigExplosivesMod.MODID, "player_variables"), new PlayerVariablesProvider());
+            }
+        }
+
+        public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+            return cap == BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY ? this.instance.cast() : LazyOptional.empty();
+        }
+
+        public Tag serializeNBT() {
+            return this.playerVariables.writeNBT();
+        }
+
+        public void deserializeNBT(Tag nbt) {
+            this.playerVariables.readNBT(nbt);
+        }
+    }
+
+    /* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BigExplosivesModVariables$PlayerVariables.class */
+    public static class PlayerVariables {
+        public double fadevariable = 0.0d;
+        public double ScreenShake = 0.0d;
+
+        public void syncPlayerVariables(Entity entity) {
+            if (entity instanceof ServerPlayer) {
+                ServerPlayer serverPlayer = (ServerPlayer) entity;
+                BigExplosivesMod.PACKET_HANDLER.send(PacketDistributor.PLAYER.with(() -> {
+                    return serverPlayer;
+                }), new PlayerVariablesSyncMessage(this));
+            }
+        }
+
+        public Tag writeNBT() {
+            CompoundTag nbt = new CompoundTag();
+            nbt.m_128347_("fadevariable", this.fadevariable);
+            nbt.m_128347_("ScreenShake", this.ScreenShake);
+            return nbt;
+        }
+
+        public void readNBT(Tag tag) {
+            CompoundTag nbt = (CompoundTag) tag;
+            this.fadevariable = nbt.m_128459_("fadevariable");
+            this.ScreenShake = nbt.m_128459_("ScreenShake");
+        }
+    }
+
+    /* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/network/BigExplosivesModVariables$PlayerVariablesSyncMessage.class */
+    public static class PlayerVariablesSyncMessage {
+        private final PlayerVariables data;
+
+        public PlayerVariablesSyncMessage(FriendlyByteBuf buffer) {
+            this.data = new PlayerVariables();
+            this.data.readNBT(buffer.m_130260_());
+        }
+
+        public PlayerVariablesSyncMessage(PlayerVariables data) {
+            this.data = data;
+        }
+
+        public static void buffer(PlayerVariablesSyncMessage message, FriendlyByteBuf buffer) {
+            buffer.m_130079_(message.data.writeNBT());
+        }
+
+        public static void handler(PlayerVariablesSyncMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+            NetworkEvent.Context context = contextSupplier.get();
+            context.enqueueWork(() -> {
+                if (!context.getDirection().getReceptionSide().isServer()) {
+                    PlayerVariables variables = (PlayerVariables) Minecraft.m_91087_().f_91074_.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new PlayerVariables());
+                    variables.fadevariable = message.data.fadevariable;
+                    variables.ScreenShake = message.data.ScreenShake;
+                }
+            });
+            context.setPacketHandled(true);
+        }
+    }
+}

--- a/src/main/java/com/hbm/particle/SmokeParticle.java
+++ b/src/main/java/com/hbm/particle/SmokeParticle.java
@@ -1,0 +1,56 @@
+package net.mcreator.nuclearcraft.client.particle;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.ParticleRenderType;
+import net.minecraft.client.particle.SpriteSet;
+import net.minecraft.client.particle.TextureSheetParticle;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/particle/SmokeParticle.class */
+public class SmokeParticle extends TextureSheetParticle {
+    private final SpriteSet spriteSet;
+
+    public static SmokeParticleProvider provider(SpriteSet spriteSet) {
+        return new SmokeParticleProvider(spriteSet);
+    }
+
+    /* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/particle/SmokeParticle$SmokeParticleProvider.class */
+    public static class SmokeParticleProvider implements ParticleProvider<SimpleParticleType> {
+        private final SpriteSet spriteSet;
+
+        public SmokeParticleProvider(SpriteSet spriteSet) {
+            this.spriteSet = spriteSet;
+        }
+
+        /* renamed from: createParticle, reason: merged with bridge method [inline-methods] */
+        public Particle m_6966_(SimpleParticleType typeIn, ClientLevel worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
+            return new SmokeParticle(worldIn, x, y, z, xSpeed, ySpeed, zSpeed, this.spriteSet);
+        }
+    }
+
+    protected SmokeParticle(ClientLevel world, double x, double y, double z, double vx, double vy, double vz, SpriteSet spriteSet) {
+        super(world, x, y, z);
+        this.spriteSet = spriteSet;
+        m_107250_(0.2f, 0.2f);
+        this.f_107225_ = Math.max(1, 60 + (this.f_107223_.m_188503_(100) - 50));
+        this.f_107226_ = 1.0f;
+        this.f_107219_ = true;
+        this.f_107215_ = vx * 1.0d;
+        this.f_107216_ = vy * 1.0d;
+        this.f_107217_ = vz * 1.0d;
+        m_108335_(spriteSet);
+    }
+
+    public ParticleRenderType m_7556_() {
+        return ParticleRenderType.f_107431_;
+    }
+
+    public void m_5989_() {
+        super.m_5989_();
+    }
+}

--- a/src/main/java/com/hbm/potion/RadiationImmunityMobEffect.java
+++ b/src/main/java/com/hbm/potion/RadiationImmunityMobEffect.java
@@ -1,0 +1,29 @@
+package net.mcreator.nuclearcraft.potion;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.mcreator.nuclearcraft.procedures.RadiationImmunityOnEffectActiveTickProcedure;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/potion/RadiationImmunityMobEffect.class */
+public class RadiationImmunityMobEffect extends MobEffect {
+    public RadiationImmunityMobEffect() {
+        super(MobEffectCategory.HARMFUL, -256);
+    }
+
+    public List<ItemStack> getCurativeItems() {
+        ArrayList<ItemStack> cures = new ArrayList<>();
+        return cures;
+    }
+
+    public void m_6742_(LivingEntity entity, int amplifier) {
+        RadiationImmunityOnEffectActiveTickProcedure.execute(entity);
+    }
+
+    public boolean m_6584_(int duration, int amplifier) {
+        return true;
+    }
+}

--- a/src/main/java/com/hbm/potion/RadiationPoisoningMobEffect.java
+++ b/src/main/java/com/hbm/potion/RadiationPoisoningMobEffect.java
@@ -1,0 +1,29 @@
+package net.mcreator.nuclearcraft.potion;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.mcreator.nuclearcraft.procedures.RadiationPoisoningActiveTickConditionProcedure;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/potion/RadiationPoisoningMobEffect.class */
+public class RadiationPoisoningMobEffect extends MobEffect {
+    public RadiationPoisoningMobEffect() {
+        super(MobEffectCategory.HARMFUL, -9765120);
+    }
+
+    public List<ItemStack> getCurativeItems() {
+        ArrayList<ItemStack> cures = new ArrayList<>();
+        return cures;
+    }
+
+    public void m_6742_(LivingEntity entity, int amplifier) {
+        RadiationPoisoningActiveTickConditionProcedure.execute(entity.m_9236_(), entity);
+    }
+
+    public boolean m_6584_(int duration, int amplifier) {
+        return true;
+    }
+}

--- a/src/main/java/com/hbm/potion/ScreenShakeEffectMobEffect.java
+++ b/src/main/java/com/hbm/potion/ScreenShakeEffectMobEffect.java
@@ -1,0 +1,50 @@
+package net.mcreator.nuclearcraft.potion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.mcreator.nuclearcraft.procedures.ScreenShakeEffectActiveTickConditionProcedure;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.extensions.common.IClientMobEffectExtensions;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/potion/ScreenShakeEffectMobEffect.class */
+public class ScreenShakeEffectMobEffect extends MobEffect {
+    public ScreenShakeEffectMobEffect() {
+        super(MobEffectCategory.NEUTRAL, -1);
+    }
+
+    public List<ItemStack> getCurativeItems() {
+        ArrayList<ItemStack> cures = new ArrayList<>();
+        return cures;
+    }
+
+    public void m_6742_(LivingEntity entity, int amplifier) {
+        ScreenShakeEffectActiveTickConditionProcedure.execute(entity);
+    }
+
+    public boolean m_6584_(int duration, int amplifier) {
+        return true;
+    }
+
+    public void initializeClient(Consumer<IClientMobEffectExtensions> consumer) {
+        consumer.accept(new IClientMobEffectExtensions() { // from class: net.mcreator.nuclearcraft.potion.ScreenShakeEffectMobEffect.1
+            public boolean isVisibleInInventory(MobEffectInstance effect) {
+                return false;
+            }
+
+            public boolean renderInventoryText(MobEffectInstance instance, EffectRenderingInventoryScreen<?> screen, GuiGraphics guiGraphics, int x, int y, int blitOffset) {
+                return false;
+            }
+
+            public boolean isVisibleInGui(MobEffectInstance effect) {
+                return false;
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/potion/WhiteOutEffectMobEffect.java
+++ b/src/main/java/com/hbm/potion/WhiteOutEffectMobEffect.java
@@ -1,0 +1,51 @@
+package net.mcreator.nuclearcraft.potion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.mcreator.nuclearcraft.procedures.WhiteOutEffectEffectStartedappliedProcedure;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.extensions.common.IClientMobEffectExtensions;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/potion/WhiteOutEffectMobEffect.class */
+public class WhiteOutEffectMobEffect extends MobEffect {
+    public WhiteOutEffectMobEffect() {
+        super(MobEffectCategory.HARMFUL, -1);
+    }
+
+    public List<ItemStack> getCurativeItems() {
+        ArrayList<ItemStack> cures = new ArrayList<>();
+        return cures;
+    }
+
+    public void m_6385_(LivingEntity entity, AttributeMap attributeMap, int amplifier) {
+        WhiteOutEffectEffectStartedappliedProcedure.execute(entity.m_9236_(), entity.m_20185_(), entity.m_20186_(), entity.m_20189_());
+    }
+
+    public boolean m_6584_(int duration, int amplifier) {
+        return true;
+    }
+
+    public void initializeClient(Consumer<IClientMobEffectExtensions> consumer) {
+        consumer.accept(new IClientMobEffectExtensions() { // from class: net.mcreator.nuclearcraft.potion.WhiteOutEffectMobEffect.1
+            public boolean isVisibleInInventory(MobEffectInstance effect) {
+                return false;
+            }
+
+            public boolean renderInventoryText(MobEffectInstance instance, EffectRenderingInventoryScreen<?> screen, GuiGraphics guiGraphics, int x, int y, int blitOffset) {
+                return false;
+            }
+
+            public boolean isVisibleInGui(MobEffectInstance effect) {
+                return false;
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/AdvancedWorkBechGuiWhileThisGUIIsOpenTickProcedure.java
+++ b/src/main/java/com/hbm/procedures/AdvancedWorkBechGuiWhileThisGUIIsOpenTickProcedure.java
@@ -1,0 +1,116 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AdvancedWorkBechGuiWhileThisGUIIsOpenTickProcedure.class */
+public class AdvancedWorkBechGuiWhileThisGUIIsOpenTickProcedure {
+    public static void execute(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (FiveHundredKgBombCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                Supplier supplier = _player.f_36096_;
+                if (supplier instanceof Supplier) {
+                    Supplier _current = supplier;
+                    Object obj = _current.get();
+                    if (obj instanceof Map) {
+                        Map _slots = (Map) obj;
+                        ItemStack _setstack = new ItemStack((ItemLike) BigExplosivesModItems.FIVE_HUNDRED_KILOGRAM_BOMB.get()).m_41777_();
+                        _setstack.m_41764_(1);
+                        ((Slot) _slots.get(Integer.valueOf((int) 16.0d))).m_5852_(_setstack);
+                        _player.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (NapalmBombCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player2 = (Player) entity;
+                Supplier supplier2 = _player2.f_36096_;
+                if (supplier2 instanceof Supplier) {
+                    Supplier _current2 = supplier2;
+                    Object obj2 = _current2.get();
+                    if (obj2 instanceof Map) {
+                        Map _slots2 = (Map) obj2;
+                        ItemStack _setstack2 = new ItemStack((ItemLike) BigExplosivesModItems.NAPALM_BOMBB.get()).m_41777_();
+                        _setstack2.m_41764_(1);
+                        ((Slot) _slots2.get(Integer.valueOf((int) 16.0d))).m_5852_(_setstack2);
+                        _player2.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (BunkerBusterCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player3 = (Player) entity;
+                Supplier supplier3 = _player3.f_36096_;
+                if (supplier3 instanceof Supplier) {
+                    Supplier _current3 = supplier3;
+                    Object obj3 = _current3.get();
+                    if (obj3 instanceof Map) {
+                        Map _slots3 = (Map) obj3;
+                        ItemStack _setstack3 = new ItemStack((ItemLike) BigExplosivesModItems.BUNKER_BUSTER_BOMB.get()).m_41777_();
+                        _setstack3.m_41764_(1);
+                        ((Slot) _slots3.get(Integer.valueOf((int) 16.0d))).m_5852_(_setstack3);
+                        _player3.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (AtomicBombCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player4 = (Player) entity;
+                Supplier supplier4 = _player4.f_36096_;
+                if (supplier4 instanceof Supplier) {
+                    Supplier _current4 = supplier4;
+                    Object obj4 = _current4.get();
+                    if (obj4 instanceof Map) {
+                        Map _slots4 = (Map) obj4;
+                        ItemStack _setstack4 = new ItemStack((ItemLike) BigExplosivesModItems.ATOM_BOMB.get()).m_41777_();
+                        _setstack4.m_41764_(1);
+                        ((Slot) _slots4.get(Integer.valueOf((int) 16.0d))).m_5852_(_setstack4);
+                        _player4.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (entity instanceof Player) {
+            Player _player5 = (Player) entity;
+            Supplier supplier5 = _player5.f_36096_;
+            if (supplier5 instanceof Supplier) {
+                Supplier _current5 = supplier5;
+                Object obj5 = _current5.get();
+                if (obj5 instanceof Map) {
+                    Map _slots5 = (Map) obj5;
+                    ((Slot) _slots5.get(Integer.valueOf((int) 16.0d))).m_5852_(ItemStack.f_41583_);
+                    _player5.f_36096_.m_38946_();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombCustomRecipeProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombCustomRecipeProcedure.java
@@ -1,0 +1,32 @@
+package net.mcreator.nuclearcraft.procedures;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombCustomRecipeProcedure.class */
+public class AtomicBombCustomRecipeProcedure {
+    /* JADX WARN: Removed duplicated region for block: B:103:0x03dd  */
+    /* JADX WARN: Removed duplicated region for block: B:113:0x0442  */
+    /* JADX WARN: Removed duplicated region for block: B:123:0x04a7  */
+    /* JADX WARN: Removed duplicated region for block: B:133:0x050c  */
+    /* JADX WARN: Removed duplicated region for block: B:13:0x0055  */
+    /* JADX WARN: Removed duplicated region for block: B:143:0x0571  */
+    /* JADX WARN: Removed duplicated region for block: B:153:0x05d6  */
+    /* JADX WARN: Removed duplicated region for block: B:163:0x0635  */
+    /* JADX WARN: Removed duplicated region for block: B:23:0x00b9  */
+    /* JADX WARN: Removed duplicated region for block: B:33:0x011d  */
+    /* JADX WARN: Removed duplicated region for block: B:43:0x0181  */
+    /* JADX WARN: Removed duplicated region for block: B:53:0x01e5  */
+    /* JADX WARN: Removed duplicated region for block: B:63:0x0249  */
+    /* JADX WARN: Removed duplicated region for block: B:73:0x02ae  */
+    /* JADX WARN: Removed duplicated region for block: B:83:0x0313  */
+    /* JADX WARN: Removed duplicated region for block: B:93:0x0378  */
+    /*
+        Code decompiled incorrectly, please refer to instructions dump.
+        To view partially-correct add '--show-bad-code' argument
+    */
+    public static boolean execute(net.minecraft.world.entity.Entity r5) {
+        /*
+            Method dump skipped, instructions count: 1616
+            To view this dump add '--comments-level debug' option
+        */
+        throw new UnsupportedOperationException("Method not decompiled: net.mcreator.nuclearcraft.procedures.AtomicBombCustomRecipeProcedure.execute(net.minecraft.world.entity.Entity):boolean");
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombDiesDuplicateProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombDiesDuplicateProcedure.java
@@ -1,0 +1,298 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.mcreator.nuclearcraft.init.BigExplosivesModMobEffects;
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractHurtingProjectile;
+import net.minecraft.world.entity.projectile.LargeFireball;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombDiesDuplicateProcedure.class */
+public class AtomicBombDiesDuplicateProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity) throws IOException {
+        if (entity == null) {
+            return;
+        }
+        new File("");
+        new JsonObject();
+        File bigexplosives = new File(FMLPaths.GAMEDIR.get().toString() + "/config/", File.separator + "bigexplosivesconfig.json");
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new FileReader(bigexplosives));
+            StringBuilder jsonstringbuilder = new StringBuilder();
+            while (true) {
+                String line = bufferedReader.readLine();
+                if (line == null) {
+                    break;
+                } else {
+                    jsonstringbuilder.append(line);
+                }
+            }
+            bufferedReader.close();
+            JsonObject mainjsonobject = (JsonObject) new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
+            double baseDamage = mainjsonobject.get("AtomicBombDamage").getAsDouble();
+            if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "teleport @s ~ ~ ~ ~ ~90");
+            }
+            for (int index0 = 0; index0 < ((int) (200.0d * 20.0d)); index0++) {
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "fill ^ ^ ^0 ^ ^ ^" + 4626322717216342016 + " air");
+                }
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "fill ^ ^ ^0 ^ ^ ^" + (20.0d * (-1.0d)) + " air");
+                }
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "teleport @s ~ ~ ~ ~4 ~-0.1");
+                }
+            }
+            BigExplosivesMod.queueServerWork(1, () -> {
+                Vec3 _center = new Vec3(x, y, z);
+                List<Entity> _entfound = world.m_6443_(Entity.class, new AABB(_center, _center).m_82400_(25.0d), e -> {
+                    return true;
+                }).stream().sorted(Comparator.comparingDouble(_entcnd -> {
+                    return _entcnd.m_20238_(_center);
+                })).toList();
+                for (Entity entity2 : _entfound) {
+                    entity2.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), (float) baseDamage);
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity = (LivingEntity) entity2;
+                        if (!_entity.m_9236_().m_5776_()) {
+                            _entity.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 220, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity2 = (LivingEntity) entity2;
+                        if (!_entity2.m_9236_().m_5776_()) {
+                            _entity2.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity3 = (LivingEntity) entity2;
+                        if (!_entity3.m_9236_().m_5776_()) {
+                            _entity3.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 8000, 0, false, true));
+                        }
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(1, () -> {
+                Vec3 _center = new Vec3(x, y, z);
+                List<Entity> _entfound = world.m_6443_(Entity.class, new AABB(_center, _center).m_82400_(35.0d), e -> {
+                    return true;
+                }).stream().sorted(Comparator.comparingDouble(_entcnd -> {
+                    return _entcnd.m_20238_(_center);
+                })).toList();
+                for (Entity entity2 : _entfound) {
+                    entity2.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), (float) (baseDamage / 2.0d));
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity = (LivingEntity) entity2;
+                        if (!_entity.m_9236_().m_5776_()) {
+                            _entity.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity2 = (LivingEntity) entity2;
+                        if (!_entity2.m_9236_().m_5776_()) {
+                            _entity2.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 150, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity3 = (LivingEntity) entity2;
+                        if (!_entity3.m_9236_().m_5776_()) {
+                            _entity3.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 6000, 0, false, true));
+                        }
+                    }
+                }
+                BigExplosivesMod.queueServerWork(1, () -> {
+                    Vec3 _center2 = new Vec3(x, y, z);
+                    List<Entity> _entfound2 = world.m_6443_(Entity.class, new AABB(_center2, _center2).m_82400_(45.0d), e2 -> {
+                        return true;
+                    }).stream().sorted(Comparator.comparingDouble(_entcnd2 -> {
+                        return _entcnd2.m_20238_(_center2);
+                    })).toList();
+                    for (Entity entity3 : _entfound2) {
+                        entity3.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), (float) (baseDamage / 4.0d));
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity4 = (LivingEntity) entity3;
+                            if (!_entity4.m_9236_().m_5776_()) {
+                                _entity4.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity5 = (LivingEntity) entity3;
+                            if (!_entity5.m_9236_().m_5776_()) {
+                                _entity5.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 150, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity6 = (LivingEntity) entity3;
+                            if (!_entity6.m_9236_().m_5776_()) {
+                                _entity6.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 4000, 0, false, true));
+                            }
+                        }
+                    }
+                });
+                BigExplosivesMod.queueServerWork(1, () -> {
+                    Vec3 _center2 = new Vec3(x, y, z);
+                    List<Entity> _entfound2 = world.m_6443_(Entity.class, new AABB(_center2, _center2).m_82400_(90.0d), e2 -> {
+                        return true;
+                    }).stream().sorted(Comparator.comparingDouble(_entcnd2 -> {
+                        return _entcnd2.m_20238_(_center2);
+                    })).toList();
+                    for (Entity entity3 : _entfound2) {
+                        entity3.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), (float) (baseDamage / 8.0d));
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity4 = (LivingEntity) entity3;
+                            if (!_entity4.m_9236_().m_5776_()) {
+                                _entity4.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity5 = (LivingEntity) entity3;
+                            if (!_entity5.m_9236_().m_5776_()) {
+                                _entity5.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 100, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity6 = (LivingEntity) entity3;
+                            if (!_entity6.m_9236_().m_5776_()) {
+                                _entity6.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 2000, 0, false, true));
+                            }
+                        }
+                    }
+                });
+            });
+            BigExplosivesMod.queueServerWork(1, () -> {
+                for (int index1 = 0; index1 < 300; index1++) {
+                    BigExplosivesMod.queueServerWork(1, () -> {
+                        int iM_6527_;
+                        if (world instanceof ServerLevel) {
+                            ServerLevel projectileLevel = (ServerLevel) world;
+                            ?? r0 = new Object() { // from class: net.mcreator.nuclearcraft.procedures.AtomicBombDiesDuplicateProcedure.1
+                                public Projectile getFireball(Level level, Entity shooter, double ax, double ay, double az) {
+                                    LargeFireball largeFireball = new LargeFireball(EntityType.f_20463_, level);
+                                    largeFireball.m_5602_(shooter);
+                                    ((AbstractHurtingProjectile) largeFireball).f_36813_ = ax;
+                                    ((AbstractHurtingProjectile) largeFireball).f_36814_ = ay;
+                                    ((AbstractHurtingProjectile) largeFireball).f_36815_ = az;
+                                    return largeFireball;
+                                }
+                            };
+                            if (entity instanceof ServerPlayer) {
+                                ServerPlayer _player = (ServerPlayer) entity;
+                                if (!_player.m_9236_().m_5776_()) {
+                                    iM_6527_ = (!_player.m_8963_().equals(_player.m_9236_().m_46472_()) || _player.m_8961_() == null) ? _player.m_9236_().m_6106_().m_6527_() : _player.m_8961_().m_123342_();
+                                } else {
+                                    iM_6527_ = 0;
+                                }
+                            }
+                            Projectile _entityToSpawn = r0.getFireball(projectileLevel, entity, 0.0d, iM_6527_ - 0.1d, 0.0d);
+                            _entityToSpawn.m_6034_(x + Mth.m_216263_(RandomSource.m_216327_(), -18.0d, 18.0d), y, z + Mth.m_216263_(RandomSource.m_216327_(), -18.0d, 18.0d));
+                            _entityToSpawn.m_6686_(0.0d, 0.0d, 0.0d, 1.0f, 0.0f);
+                            projectileLevel.m_7967_(_entityToSpawn);
+                        }
+                    });
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.ATOMIC_BOMB_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y - 3.0d, z), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:boom")), SoundSource.NEUTRAL, 100.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:boom")), SoundSource.NEUTRAL, 100.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombclose")), SoundSource.NEUTRAL, 200.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombclose")), SoundSource.NEUTRAL, 200.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombfar")), SoundSource.NEUTRAL, 400.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombfar")), SoundSource.NEUTRAL, 400.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombextremelyfar")), SoundSource.NEUTRAL, 600.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombextremelyfar")), SoundSource.NEUTRAL, 600.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:superfarexplosion")), SoundSource.NEUTRAL, 1000.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:superfarexplosion")), SoundSource.NEUTRAL, 1000.0f, 1.0f, false);
+                    }
+                }
+            });
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                _player.m_36335_().m_41524_((Item) BigExplosivesModItems.TEST.get(), 600);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombEntityDiesProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombEntityDiesProcedure.java
@@ -1,0 +1,295 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.mcreator.nuclearcraft.init.BigExplosivesModMobEffects;
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractHurtingProjectile;
+import net.minecraft.world.entity.projectile.LargeFireball;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombEntityDiesProcedure.class */
+public class AtomicBombEntityDiesProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity) throws IOException {
+        if (entity == null) {
+            return;
+        }
+        new File("");
+        new JsonObject();
+        File bigexplosives = new File(FMLPaths.GAMEDIR.get().toString() + "/config/", File.separator + "bigexplosivesconfig.json");
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new FileReader(bigexplosives));
+            StringBuilder jsonstringbuilder = new StringBuilder();
+            while (true) {
+                String line = bufferedReader.readLine();
+                if (line == null) {
+                    break;
+                } else {
+                    jsonstringbuilder.append(line);
+                }
+            }
+            bufferedReader.close();
+            if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "teleport @s ~ ~ ~ ~ ~90");
+            }
+            for (int index0 = 0; index0 < ((int) (200.0d * 20.0d)); index0++) {
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "fill ^ ^ ^0 ^ ^ ^" + 4626322717216342016 + " air");
+                }
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "fill ^ ^ ^0 ^ ^ ^" + (20.0d * (-1.0d)) + " air");
+                }
+                if (!entity.m_9236_().m_5776_() && entity.m_20194_() != null) {
+                    entity.m_20194_().m_129892_().m_230957_(new CommandSourceStack(CommandSource.f_80164_, entity.m_20182_(), entity.m_20155_(), entity.m_9236_() instanceof ServerLevel ? (ServerLevel) entity.m_9236_() : null, 4, entity.m_7755_().getString(), entity.m_5446_(), entity.m_9236_().m_7654_(), entity), "teleport @s ~ ~ ~ ~4 ~-0.1");
+                }
+            }
+            BigExplosivesMod.queueServerWork(1, () -> {
+                Vec3 _center = new Vec3(x, y, z);
+                List<Entity> _entfound = world.m_6443_(Entity.class, new AABB(_center, _center).m_82400_(25.0d), e -> {
+                    return true;
+                }).stream().sorted(Comparator.comparingDouble(_entcnd -> {
+                    return _entcnd.m_20238_(_center);
+                })).toList();
+                for (Entity entity2 : _entfound) {
+                    entity2.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), 120.0f);
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity = (LivingEntity) entity2;
+                        if (!_entity.m_9236_().m_5776_()) {
+                            _entity.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 220, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity2 = (LivingEntity) entity2;
+                        if (!_entity2.m_9236_().m_5776_()) {
+                            _entity2.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity3 = (LivingEntity) entity2;
+                        if (!_entity3.m_9236_().m_5776_()) {
+                            _entity3.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 8000, 0, false, true));
+                        }
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(1, () -> {
+                Vec3 _center = new Vec3(x, y, z);
+                List<Entity> _entfound = world.m_6443_(Entity.class, new AABB(_center, _center).m_82400_(35.0d), e -> {
+                    return true;
+                }).stream().sorted(Comparator.comparingDouble(_entcnd -> {
+                    return _entcnd.m_20238_(_center);
+                })).toList();
+                for (Entity entity2 : _entfound) {
+                    entity2.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), 60.0f);
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity = (LivingEntity) entity2;
+                        if (!_entity.m_9236_().m_5776_()) {
+                            _entity.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity2 = (LivingEntity) entity2;
+                        if (!_entity2.m_9236_().m_5776_()) {
+                            _entity2.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 150, 0, false, false));
+                        }
+                    }
+                    if (entity2 instanceof LivingEntity) {
+                        LivingEntity _entity3 = (LivingEntity) entity2;
+                        if (!_entity3.m_9236_().m_5776_()) {
+                            _entity3.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 6000, 0, false, true));
+                        }
+                    }
+                }
+                BigExplosivesMod.queueServerWork(1, () -> {
+                    Vec3 _center2 = new Vec3(x, y, z);
+                    List<Entity> _entfound2 = world.m_6443_(Entity.class, new AABB(_center2, _center2).m_82400_(45.0d), e2 -> {
+                        return true;
+                    }).stream().sorted(Comparator.comparingDouble(_entcnd2 -> {
+                        return _entcnd2.m_20238_(_center2);
+                    })).toList();
+                    for (Entity entity3 : _entfound2) {
+                        entity3.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), 30.0f);
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity4 = (LivingEntity) entity3;
+                            if (!_entity4.m_9236_().m_5776_()) {
+                                _entity4.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity5 = (LivingEntity) entity3;
+                            if (!_entity5.m_9236_().m_5776_()) {
+                                _entity5.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 150, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity6 = (LivingEntity) entity3;
+                            if (!_entity6.m_9236_().m_5776_()) {
+                                _entity6.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 4000, 0, false, true));
+                            }
+                        }
+                    }
+                });
+                BigExplosivesMod.queueServerWork(1, () -> {
+                    Vec3 _center2 = new Vec3(x, y, z);
+                    List<Entity> _entfound2 = world.m_6443_(Entity.class, new AABB(_center2, _center2).m_82400_(90.0d), e2 -> {
+                        return true;
+                    }).stream().sorted(Comparator.comparingDouble(_entcnd2 -> {
+                        return _entcnd2.m_20238_(_center2);
+                    })).toList();
+                    for (Entity entity3 : _entfound2) {
+                        entity3.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:atomized")))), 15.0f);
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity4 = (LivingEntity) entity3;
+                            if (!_entity4.m_9236_().m_5776_()) {
+                                _entity4.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.SCREEN_SHAKE_EFFECT.get(), 380, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity5 = (LivingEntity) entity3;
+                            if (!_entity5.m_9236_().m_5776_()) {
+                                _entity5.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get(), 100, 0, false, false));
+                            }
+                        }
+                        if (entity3 instanceof LivingEntity) {
+                            LivingEntity _entity6 = (LivingEntity) entity3;
+                            if (!_entity6.m_9236_().m_5776_()) {
+                                _entity6.m_7292_(new MobEffectInstance((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get(), 2000, 0, false, true));
+                            }
+                        }
+                    }
+                });
+            });
+            BigExplosivesMod.queueServerWork(1, () -> {
+                for (int index1 = 0; index1 < 300; index1++) {
+                    BigExplosivesMod.queueServerWork(1, () -> {
+                        int iM_6527_;
+                        if (world instanceof ServerLevel) {
+                            ServerLevel projectileLevel = (ServerLevel) world;
+                            ?? r0 = new Object() { // from class: net.mcreator.nuclearcraft.procedures.AtomicBombEntityDiesProcedure.1
+                                public Projectile getFireball(Level level, Entity shooter, double ax, double ay, double az) {
+                                    LargeFireball largeFireball = new LargeFireball(EntityType.f_20463_, level);
+                                    largeFireball.m_5602_(shooter);
+                                    ((AbstractHurtingProjectile) largeFireball).f_36813_ = ax;
+                                    ((AbstractHurtingProjectile) largeFireball).f_36814_ = ay;
+                                    ((AbstractHurtingProjectile) largeFireball).f_36815_ = az;
+                                    return largeFireball;
+                                }
+                            };
+                            if (entity instanceof ServerPlayer) {
+                                ServerPlayer _player = (ServerPlayer) entity;
+                                if (!_player.m_9236_().m_5776_()) {
+                                    iM_6527_ = (!_player.m_8963_().equals(_player.m_9236_().m_46472_()) || _player.m_8961_() == null) ? _player.m_9236_().m_6106_().m_6527_() : _player.m_8961_().m_123342_();
+                                } else {
+                                    iM_6527_ = 0;
+                                }
+                            }
+                            Projectile _entityToSpawn = r0.getFireball(projectileLevel, entity, 0.0d, iM_6527_ - 0.1d, 0.0d);
+                            _entityToSpawn.m_6034_(x + Mth.m_216263_(RandomSource.m_216327_(), -18.0d, 18.0d), y, z + Mth.m_216263_(RandomSource.m_216327_(), -18.0d, 18.0d));
+                            _entityToSpawn.m_6686_(0.0d, 0.0d, 0.0d, 1.0f, 0.0f);
+                            projectileLevel.m_7967_(_entityToSpawn);
+                        }
+                    });
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.ATOMIC_BOMB_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y - 3.0d, z), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:boom")), SoundSource.NEUTRAL, 100.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:boom")), SoundSource.NEUTRAL, 100.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombclose")), SoundSource.NEUTRAL, 200.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombclose")), SoundSource.NEUTRAL, 200.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombfar")), SoundSource.NEUTRAL, 400.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombfar")), SoundSource.NEUTRAL, 400.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombextremelyfar")), SoundSource.NEUTRAL, 600.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:atombombextremelyfar")), SoundSource.NEUTRAL, 600.0f, 1.0f, false);
+                    }
+                }
+            });
+            BigExplosivesMod.queueServerWork(3, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:superfarexplosion")), SoundSource.NEUTRAL, 1000.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:superfarexplosion")), SoundSource.NEUTRAL, 1000.0f, 1.0f, false);
+                    }
+                }
+            });
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                _player.m_36335_().m_41524_((Item) BigExplosivesModItems.TEST.get(), 600);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombEntityFallProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombEntityFallProcedure.java
@@ -1,0 +1,17 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombEntityFallProcedure.class */
+public class AtomicBombEntityFallProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268433_)), 30.0f);
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombExplosionOnEntityTickUpdateProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombExplosionOnEntityTickUpdateProcedure.java
@@ -1,0 +1,34 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombExplosionOnEntityTickUpdateProcedure.class */
+public class AtomicBombExplosionOnEntityTickUpdateProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (entity instanceof LivingEntity) {
+            LivingEntity _entity = (LivingEntity) entity;
+            _entity.m_21219_();
+        }
+        BigExplosivesMod.queueServerWork(380, () -> {
+            if (entity.m_6084_()) {
+                if (!entity.m_9236_().m_5776_()) {
+                    entity.m_146870_();
+                }
+                if (entity instanceof LivingEntity) {
+                    LivingEntity _entity2 = (LivingEntity) entity;
+                    _entity2.m_21219_();
+                }
+            }
+        });
+        if (entity instanceof LivingEntity) {
+            LivingEntity _entity2 = (LivingEntity) entity;
+            _entity2.m_21219_();
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/AtomicBombOnEntityTickUpdateProcedure.java
+++ b/src/main/java/com/hbm/procedures/AtomicBombOnEntityTickUpdateProcedure.java
@@ -1,0 +1,25 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/AtomicBombOnEntityTickUpdateProcedure.class */
+public class AtomicBombOnEntityTickUpdateProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (entity.m_20072_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268433_)), 100.0f);
+        }
+        if (entity.m_20069_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268433_)), 100.0f);
+        }
+        if (entity.m_5842_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268433_)), 100.0f);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/BasicWorkBenchGuiWhileThisGUIIsOpenTickProcedure.java
+++ b/src/main/java/com/hbm/procedures/BasicWorkBenchGuiWhileThisGUIIsOpenTickProcedure.java
@@ -1,0 +1,95 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/BasicWorkBenchGuiWhileThisGUIIsOpenTickProcedure.class */
+public class BasicWorkBenchGuiWhileThisGUIIsOpenTickProcedure {
+    public static void execute(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (TenKgBombCutomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                Supplier supplier = _player.f_36096_;
+                if (supplier instanceof Supplier) {
+                    Supplier _current = supplier;
+                    Object obj = _current.get();
+                    if (obj instanceof Map) {
+                        Map _slots = (Map) obj;
+                        ItemStack _setstack = new ItemStack((ItemLike) BigExplosivesModItems.TEN_KG_BOMB.get()).m_41777_();
+                        _setstack.m_41764_(1);
+                        ((Slot) _slots.get(Integer.valueOf((int) 7.0d))).m_5852_(_setstack);
+                        _player.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (TenkgFireCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player2 = (Player) entity;
+                Supplier supplier2 = _player2.f_36096_;
+                if (supplier2 instanceof Supplier) {
+                    Supplier _current2 = supplier2;
+                    Object obj2 = _current2.get();
+                    if (obj2 instanceof Map) {
+                        Map _slots2 = (Map) obj2;
+                        ItemStack _setstack2 = new ItemStack((ItemLike) BigExplosivesModItems.TEN_KG_NAPALM_BOMB.get()).m_41777_();
+                        _setstack2.m_41764_(1);
+                        ((Slot) _slots2.get(Integer.valueOf((int) 7.0d))).m_5852_(_setstack2);
+                        _player2.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (TwoHundredAndFiftyCustomRecipeProcedure.execute(entity)) {
+            if (entity instanceof Player) {
+                Player _player3 = (Player) entity;
+                Supplier supplier3 = _player3.f_36096_;
+                if (supplier3 instanceof Supplier) {
+                    Supplier _current3 = supplier3;
+                    Object obj3 = _current3.get();
+                    if (obj3 instanceof Map) {
+                        Map _slots3 = (Map) obj3;
+                        ItemStack _setstack3 = new ItemStack((ItemLike) BigExplosivesModItems.TWO_HUNDRED_AND_FIFTY_KG_BOMB.get()).m_41777_();
+                        _setstack3.m_41764_(1);
+                        ((Slot) _slots3.get(Integer.valueOf((int) 7.0d))).m_5852_(_setstack3);
+                        _player3.f_36096_.m_38946_();
+                        return;
+                    }
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (entity instanceof Player) {
+            Player _player4 = (Player) entity;
+            Supplier supplier4 = _player4.f_36096_;
+            if (supplier4 instanceof Supplier) {
+                Supplier _current4 = supplier4;
+                Object obj4 = _current4.get();
+                if (obj4 instanceof Map) {
+                    Map _slots4 = (Map) obj4;
+                    ((Slot) _slots4.get(Integer.valueOf((int) 7.0d))).m_5852_(ItemStack.f_41583_);
+                    _player4.f_36096_.m_38946_();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/CakeBombDesignatorDropProcedure.java
+++ b/src/main/java/com/hbm/procedures/CakeBombDesignatorDropProcedure.java
@@ -1,0 +1,58 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/CakeBombDesignatorDropProcedure.class */
+public class CakeBombDesignatorDropProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity, ItemStack itemstack) {
+        if (entity == null) {
+            return;
+        }
+        if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+            double Scaling2 = 0.0d + 250.0d;
+            if (world instanceof ServerLevel) {
+                Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.CAKE_BOMB.get()).m_262496_((ServerLevel) world, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + 400, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_()), MobSpawnType.MOB_SUMMONED);
+                if (entityToSpawn != null) {
+                    entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                }
+            }
+        }
+        BigExplosivesMod.queueServerWork(1, () -> {
+            if (itemstack.m_220157_(1, RandomSource.m_216327_(), (ServerPlayer) null)) {
+                itemstack.m_41774_(1);
+                itemstack.m_41721_(0);
+            }
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                _player.m_36335_().m_41524_((Item) BigExplosivesModItems.FIVE_HUNDRED_KG_BOMB_DESIGNATOR.get(), 300);
+            }
+        });
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f, false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/CakeBombEntityFallsProcedure.java
+++ b/src/main/java/com/hbm/procedures/CakeBombEntityFallsProcedure.java
@@ -1,0 +1,35 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/CakeBombEntityFallsProcedure.class */
+public class CakeBombEntityFallsProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        if (world instanceof ServerLevel) {
+            ((ServerLevel) world).m_8767_(ParticleTypes.f_123748_, x, y, z, 1000, 10.0d, 1.0d, 10.0d, 1.0d);
+        }
+        for (int index0 = 0; index0 < 50; index0++) {
+            world.m_7731_(BlockPos.m_274561_(x + Mth.m_216263_(RandomSource.m_216327_(), -10.0d, 10.0d), y, z + Mth.m_216263_(RandomSource.m_216327_(), -10.0d, 10.0d)), Blocks.f_50145_.m_49966_(), 3);
+        }
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:partyhorn")), SoundSource.NEUTRAL, 5.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:partyhorn")), SoundSource.NEUTRAL, 5.0f, 1.0f, false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/ConfigProcedure.java
+++ b/src/main/java/com/hbm/procedures/ConfigProcedure.java
@@ -1,0 +1,59 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.loading.FMLPaths;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/ConfigProcedure.class */
+public class ConfigProcedure {
+    @SubscribeEvent
+    public static void init(FMLCommonSetupEvent event) throws IOException {
+        execute();
+    }
+
+    public static void execute() throws IOException {
+        execute(null);
+    }
+
+    private static void execute(@Nullable Event event) throws IOException {
+        new File("");
+        JsonObject mainjsonobject = new JsonObject();
+        File bigexplosives = new File(FMLPaths.GAMEDIR.get().toString() + "/config/", File.separator + "bigexplosivesconfig.json");
+        if (!bigexplosives.exists()) {
+            try {
+                bigexplosives.getParentFile().mkdirs();
+                bigexplosives.createNewFile();
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+            mainjsonobject.addProperty("#Test", 0);
+            mainjsonobject.addProperty("250kgRandomBombAmount", 2);
+            mainjsonobject.addProperty("250kgAccurateBomb", true);
+            mainjsonobject.addProperty("10KgBarrageAmount", 12);
+            mainjsonobject.addProperty("NapalmBarrageAmount", 16);
+            mainjsonobject.addProperty("BunkerBusterTicks", 190);
+            mainjsonobject.addProperty("AtomicBombDamage", 120);
+            mainjsonobject.addProperty("AmountOfExplosions500kgSpawns", 30);
+            mainjsonobject.addProperty("WidthOfThe500kgExplosionSpawnRadius", 13);
+            mainjsonobject.addProperty("4thOfJulyBombAmount", 8);
+            Gson mainGSONBuilderVariable = new GsonBuilder().setPrettyPrinting().create();
+            try {
+                FileWriter fileWriter = new FileWriter(bigexplosives);
+                fileWriter.write(mainGSONBuilderVariable.toJson(mainjsonobject));
+                fileWriter.close();
+            } catch (IOException exception2) {
+                exception2.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/CoordStorerEntitySwingsItemProcedure.java
+++ b/src/main/java/com/hbm/procedures/CoordStorerEntitySwingsItemProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/CoordStorerEntitySwingsItemProcedure.class */
+public class CoordStorerEntitySwingsItemProcedure {
+    public static void execute(LevelAccessor world, ItemStack itemstack) {
+        if (world instanceof ServerLevel) {
+            ServerLevel _level = (ServerLevel) world;
+            Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.FIVE_BOMB.get()).m_262496_(_level, BlockPos.m_274561_(itemstack.m_41784_().m_128459_("itemX"), 400.0d, itemstack.m_41784_().m_128459_("itemZ")), MobSpawnType.MOB_SUMMONED);
+            if (entityToSpawn != null) {
+                entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/CoordStorerRightclickedProcedure.java
+++ b/src/main/java/com/hbm/procedures/CoordStorerRightclickedProcedure.java
@@ -1,0 +1,41 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/CoordStorerRightclickedProcedure.class */
+public class CoordStorerRightclickedProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity, ItemStack itemstack) {
+        if (entity == null) {
+            return;
+        }
+        if (world.m_46861_(BlockPos.m_274561_(x, y, z))) {
+            itemstack.m_41784_().m_128347_("itemX", x);
+            itemstack.m_41784_().m_128347_("itemZ", z);
+            double dM_128459_ = itemstack.m_41784_().m_128459_("itemX");
+            itemstack.m_41784_().m_128459_("itemZ");
+            itemstack.m_41714_(Component.m_237113_(" X: " + dM_128459_ + " Z: " + itemstack));
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                if (!_player.m_9236_().m_5776_()) {
+                    double dM_128459_2 = itemstack.m_41784_().m_128459_("itemX");
+                    itemstack.m_41784_().m_128459_("itemZ");
+                    _player.m_5661_(Component.m_237113_(" X: " + dM_128459_2 + " Z: " + _player), false);
+                    return;
+                }
+                return;
+            }
+            return;
+        }
+        if (entity instanceof Player) {
+            Player _player2 = (Player) entity;
+            if (!_player2.m_9236_().m_5776_()) {
+                _player2.m_5661_(Component.m_237113_("No satilites found"), false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/DamageTestPlayerCollidesWithThisEntityProcedure.java
+++ b/src/main/java/com/hbm/procedures/DamageTestPlayerCollidesWithThisEntityProcedure.java
@@ -1,0 +1,19 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/DamageTestPlayerCollidesWithThisEntityProcedure.class */
+public class DamageTestPlayerCollidesWithThisEntityProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        for (int index0 = 0; index0 < 100; index0++) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268433_)), 1.0f);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveBombEntityDiesProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveBombEntityDiesProcedure.java
@@ -1,0 +1,25 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveBombEntityDiesProcedure.class */
+public class FiveBombEntityDiesProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        BigExplosivesMod.queueServerWork(2, () -> {
+            if (world instanceof ServerLevel) {
+                ServerLevel _level = (ServerLevel) world;
+                Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.FIVE_HUNDRED_KG_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y, z), MobSpawnType.MOB_SUMMONED);
+                if (entityToSpawn != null) {
+                    entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveBombWaterExplodeProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveBombWaterExplodeProcedure.java
@@ -1,0 +1,34 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveBombWaterExplodeProcedure.class */
+public class FiveBombWaterExplodeProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity) {
+        if (entity != null && entity.m_20069_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268565_)), 100.0f);
+            BigExplosivesMod.queueServerWork(1, () -> {
+                if (world instanceof Level) {
+                    Level _level = (Level) world;
+                    if (!_level.m_5776_()) {
+                        _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:underwaterexplode")), SoundSource.NEUTRAL, 200.0f, 1.0f);
+                    } else {
+                        _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:underwaterexplode")), SoundSource.NEUTRAL, 200.0f, 1.0f, false);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgBombCustomRecipeProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgBombCustomRecipeProcedure.java
@@ -1,0 +1,32 @@
+package net.mcreator.nuclearcraft.procedures;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgBombCustomRecipeProcedure.class */
+public class FiveHundredKgBombCustomRecipeProcedure {
+    /* JADX WARN: Removed duplicated region for block: B:103:0x03dd  */
+    /* JADX WARN: Removed duplicated region for block: B:113:0x0442  */
+    /* JADX WARN: Removed duplicated region for block: B:123:0x04a7  */
+    /* JADX WARN: Removed duplicated region for block: B:133:0x050c  */
+    /* JADX WARN: Removed duplicated region for block: B:13:0x0055  */
+    /* JADX WARN: Removed duplicated region for block: B:143:0x0571  */
+    /* JADX WARN: Removed duplicated region for block: B:153:0x05d6  */
+    /* JADX WARN: Removed duplicated region for block: B:163:0x0635  */
+    /* JADX WARN: Removed duplicated region for block: B:23:0x00b9  */
+    /* JADX WARN: Removed duplicated region for block: B:33:0x011d  */
+    /* JADX WARN: Removed duplicated region for block: B:43:0x0181  */
+    /* JADX WARN: Removed duplicated region for block: B:53:0x01e5  */
+    /* JADX WARN: Removed duplicated region for block: B:63:0x0249  */
+    /* JADX WARN: Removed duplicated region for block: B:73:0x02ae  */
+    /* JADX WARN: Removed duplicated region for block: B:83:0x0313  */
+    /* JADX WARN: Removed duplicated region for block: B:93:0x0378  */
+    /*
+        Code decompiled incorrectly, please refer to instructions dump.
+        To view partially-correct add '--show-bad-code' argument
+    */
+    public static boolean execute(net.minecraft.world.entity.Entity r5) {
+        /*
+            Method dump skipped, instructions count: 1616
+            To view this dump add '--comments-level debug' option
+        */
+        throw new UnsupportedOperationException("Method not decompiled: net.mcreator.nuclearcraft.procedures.FiveHundredKgBombCustomRecipeProcedure.execute(net.minecraft.world.entity.Entity):boolean");
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgBombDesignatorPlayerFinishesUsingItemProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgBombDesignatorPlayerFinishesUsingItemProcedure.java
@@ -1,0 +1,58 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgBombDesignatorPlayerFinishesUsingItemProcedure.class */
+public class FiveHundredKgBombDesignatorPlayerFinishesUsingItemProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity, ItemStack itemstack) {
+        if (entity == null) {
+            return;
+        }
+        if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+            double Scaling2 = 0.0d + 250.0d;
+            if (world instanceof ServerLevel) {
+                Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.FIVE_BOMB.get()).m_262496_((ServerLevel) world, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + 400, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_()), MobSpawnType.MOB_SUMMONED);
+                if (entityToSpawn != null) {
+                    entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                }
+            }
+        }
+        BigExplosivesMod.queueServerWork(1, () -> {
+            if (itemstack.m_220157_(1, RandomSource.m_216327_(), (ServerPlayer) null)) {
+                itemstack.m_41774_(1);
+                itemstack.m_41721_(0);
+            }
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                _player.m_36335_().m_41524_((Item) BigExplosivesModItems.FIVE_HUNDRED_KG_BOMB_DESIGNATOR.get(), 300);
+            }
+        });
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f, false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgBombDesignatorRightclickedProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgBombDesignatorRightclickedProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgBombDesignatorRightclickedProcedure.class */
+public class FiveHundredKgBombDesignatorRightclickedProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double Scaling = 0.0d;
+        for (int index0 = 0; index0 < 500; index0++) {
+            if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+                Scaling += 1.0d;
+            }
+            world.m_7106_(ParticleTypes.f_123748_, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_(), 0.0d, 1.0d, 0.0d);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgBombEntityDiesProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgBombEntityDiesProcedure.java
@@ -1,0 +1,61 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgBombEntityDiesProcedure.class */
+public class FiveHundredKgBombEntityDiesProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) throws IOException {
+        new File("");
+        new JsonObject();
+        File bigexplosives = new File(FMLPaths.GAMEDIR.get().toString() + "/config/", File.separator + "bigexplosivesconfig.json");
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new FileReader(bigexplosives));
+            StringBuilder jsonstringbuilder = new StringBuilder();
+            while (true) {
+                String line = bufferedReader.readLine();
+                if (line == null) {
+                    break;
+                } else {
+                    jsonstringbuilder.append(line);
+                }
+            }
+            bufferedReader.close();
+            JsonObject mainjsonobject = (JsonObject) new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
+            if (world instanceof Level) {
+                Level _level = (Level) world;
+                if (!_level.m_5776_()) {
+                    _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:big_bomb")), SoundSource.MASTER, 200.0f, 1.0f);
+                } else {
+                    _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:big_bomb")), SoundSource.MASTER, 200.0f, 1.0f, false);
+                }
+            }
+            for (int index0 = 0; index0 < ((int) mainjsonobject.get("AmountOfExplosions500kgSpawns").getAsDouble()); index0++) {
+                if (world instanceof Level) {
+                    Level _level2 = (Level) world;
+                    if (!_level2.m_5776_()) {
+                        _level2.m_254849_((Entity) null, x + Mth.m_216263_(RandomSource.m_216327_(), mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble() - (mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble() * 2.0d), mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble()), y + Mth.m_216263_(RandomSource.m_216327_(), -7.0d, 5.0d), z + Mth.m_216263_(RandomSource.m_216327_(), mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble() - (mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble() * 2.0d), mainjsonobject.get("WidthOfThe500kgExplosionSpawnRadius").getAsDouble()), 6.0f, Level.ExplosionInteraction.TNT);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgExplosionOnEntityTickUpdateProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgExplosionOnEntityTickUpdateProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.init.BigExplosivesModParticleTypes;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgExplosionOnEntityTickUpdateProcedure.class */
+public class FiveHundredKgExplosionOnEntityTickUpdateProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        for (int index0 = 0; index0 < 3; index0++) {
+            if (world instanceof ServerLevel) {
+                ServerLevel _level = (ServerLevel) world;
+                _level.m_8767_((SimpleParticleType) BigExplosivesModParticleTypes.SMOKE.get(), x, y, z, 50, 4.0d, 4.0d, 4.0d, 0.3d);
+            }
+            if (world instanceof ServerLevel) {
+                ServerLevel _level2 = (ServerLevel) world;
+                _level2.m_8767_(ParticleTypes.f_123778_, x, y, z, 50, 4.0d, 4.0d, 4.0d, 0.3d);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/FiveHundredKgExplosionOnInitialEntitySpawnProcedure.java
+++ b/src/main/java/com/hbm/procedures/FiveHundredKgExplosionOnInitialEntitySpawnProcedure.java
@@ -1,0 +1,19 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/FiveHundredKgExplosionOnInitialEntitySpawnProcedure.class */
+public class FiveHundredKgExplosionOnInitialEntitySpawnProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        BigExplosivesMod.queueServerWork(90, () -> {
+            if (entity.m_6084_() && !entity.m_9236_().m_5776_()) {
+                entity.m_146870_();
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/GeckoAdvancedWorkbenchOnBlockRightClickedProcedure.java
+++ b/src/main/java/com/hbm/procedures/GeckoAdvancedWorkbenchOnBlockRightClickedProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/GeckoAdvancedWorkbenchOnBlockRightClickedProcedure.class */
+public class GeckoAdvancedWorkbenchOnBlockRightClickedProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        for (int index0 = 0; index0 < 1; index0++) {
+            BlockPos _pos = BlockPos.m_274561_(x, y, z);
+            BlockState _bs = world.m_8055_(_pos);
+            IntegerProperty integerPropertyM_61081_ = _bs.m_60734_().m_49965_().m_61081_("animation");
+            if (integerPropertyM_61081_ instanceof IntegerProperty) {
+                IntegerProperty _integerProp = integerPropertyM_61081_;
+                if (_integerProp.m_6908_().contains(1)) {
+                    world.m_7731_(_pos, (BlockState) _bs.m_61124_(_integerProp, 1), 3);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/GeckoAdvancedWorkbenchOnTickUpdateProcedure.java
+++ b/src/main/java/com/hbm/procedures/GeckoAdvancedWorkbenchOnTickUpdateProcedure.java
@@ -1,0 +1,21 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/GeckoAdvancedWorkbenchOnTickUpdateProcedure.class */
+public class GeckoAdvancedWorkbenchOnTickUpdateProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        BlockPos _pos = BlockPos.m_274561_(x, y, z);
+        BlockState _bs = world.m_8055_(_pos);
+        IntegerProperty integerPropertyM_61081_ = _bs.m_60734_().m_49965_().m_61081_("animation");
+        if (integerPropertyM_61081_ instanceof IntegerProperty) {
+            IntegerProperty _integerProp = integerPropertyM_61081_;
+            if (_integerProp.m_6908_().contains(1)) {
+                world.m_7731_(_pos, (BlockState) _bs.m_61124_(_integerProp, 1), 3);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/ItemTakenFromAdvancedOutputProcedure.java
+++ b/src/main/java/com/hbm/procedures/ItemTakenFromAdvancedOutputProcedure.java
@@ -1,0 +1,34 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/ItemTakenFromAdvancedOutputProcedure.class */
+public class ItemTakenFromAdvancedOutputProcedure {
+    public static double execute(Entity entity) {
+        if (entity == null) {
+            return 0.0d;
+        }
+        double slor = 0.0d;
+        for (int index0 = 0; index0 < 16; index0++) {
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                Supplier supplier = _player.f_36096_;
+                if (supplier instanceof Supplier) {
+                    Supplier _current = supplier;
+                    Object obj = _current.get();
+                    if (obj instanceof Map) {
+                        Map _slots = (Map) obj;
+                        ((Slot) _slots.get(Integer.valueOf((int) slor))).m_6201_(1);
+                        _player.f_36096_.m_38946_();
+                    }
+                }
+            }
+            slor += 1.0d;
+        }
+        return 0.0d;
+    }
+}

--- a/src/main/java/com/hbm/procedures/ItemTakenFromBasicOutputSlotProcedure.java
+++ b/src/main/java/com/hbm/procedures/ItemTakenFromBasicOutputSlotProcedure.java
@@ -1,0 +1,33 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/ItemTakenFromBasicOutputSlotProcedure.class */
+public class ItemTakenFromBasicOutputSlotProcedure {
+    public static void execute(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double slot = 0.0d;
+        for (int index0 = 0; index0 < 7; index0++) {
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                Supplier supplier = _player.f_36096_;
+                if (supplier instanceof Supplier) {
+                    Supplier _current = supplier;
+                    Object obj = _current.get();
+                    if (obj instanceof Map) {
+                        Map _slots = (Map) obj;
+                        ((Slot) _slots.get(Integer.valueOf((int) slot))).m_6201_(1);
+                        _player.f_36096_.m_38946_();
+                    }
+                }
+            }
+            slot += 1.0d;
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/NukeTestEntityFallsProcedure.java
+++ b/src/main/java/com/hbm/procedures/NukeTestEntityFallsProcedure.java
@@ -1,0 +1,45 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/NukeTestEntityFallsProcedure.class */
+public class NukeTestEntityFallsProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:medium_bomb")), SoundSource.NEUTRAL, 100.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:medium_bomb")), SoundSource.NEUTRAL, 100.0f, 1.0f, false);
+            }
+        }
+        if (world instanceof Level) {
+            Level _level2 = (Level) world;
+            if (!_level2.m_5776_()) {
+                _level2.m_254849_((Entity) null, x, y, z, 8.0f, Level.ExplosionInteraction.TNT);
+            }
+        }
+        BigExplosivesMod.queueServerWork(1, () -> {
+            if (world instanceof ServerLevel) {
+                ServerLevel _level3 = (ServerLevel) world;
+                Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_HUNDRED_FIFTY_KG_EXPLOSION.get()).m_262496_(_level3, BlockPos.m_274561_(x, y, z), MobSpawnType.MOB_SUMMONED);
+                if (entityToSpawn != null) {
+                    entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/RadiationImmunityOnEffectActiveTickProcedure.java
+++ b/src/main/java/com/hbm/procedures/RadiationImmunityOnEffectActiveTickProcedure.java
@@ -1,0 +1,16 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.init.BigExplosivesModMobEffects;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/RadiationImmunityOnEffectActiveTickProcedure.class */
+public class RadiationImmunityOnEffectActiveTickProcedure {
+    public static void execute(Entity entity) {
+        if (entity != null && (entity instanceof LivingEntity)) {
+            LivingEntity _entity = (LivingEntity) entity;
+            _entity.m_21195_((MobEffect) BigExplosivesModMobEffects.RADIATION_POISONING.get());
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/RadiationPoisoningActiveTickConditionProcedure.java
+++ b/src/main/java/com/hbm/procedures/RadiationPoisoningActiveTickConditionProcedure.java
@@ -1,0 +1,75 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/RadiationPoisoningActiveTickConditionProcedure.class */
+public class RadiationPoisoningActiveTickConditionProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (Math.random() < 1.0d) {
+            if (entity instanceof ServerPlayer) {
+                ServerPlayer _player = (ServerPlayer) entity;
+                Advancement _adv = _player.f_8924_.m_129889_().m_136041_(new ResourceLocation("big_explosives:acute_radiation_syndrome"));
+                AdvancementProgress _ap = _player.m_8960_().m_135996_(_adv);
+                if (!_ap.m_8193_()) {
+                    for (String criteria : _ap.m_8219_()) {
+                        _player.m_8960_().m_135988_(_adv, criteria);
+                    }
+                }
+            }
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity = (LivingEntity) entity;
+                if (!_entity.m_9236_().m_5776_()) {
+                    _entity.m_7292_(new MobEffectInstance(MobEffects.f_19619_, 200, 0));
+                }
+            }
+            if (entity instanceof Player) {
+                ((Player) entity).m_36399_(0.01f);
+            }
+        }
+        if (Math.random() < 0.005d && (entity instanceof LivingEntity)) {
+            LivingEntity _entity2 = (LivingEntity) entity;
+            if (!_entity2.m_9236_().m_5776_()) {
+                _entity2.m_7292_(new MobEffectInstance(MobEffects.f_19614_, (int) Mth.m_216263_(RandomSource.m_216327_(), 60.0d, 120.0d), 0, false, false));
+            }
+        }
+        if (Math.random() < 5.0E-4d) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(ResourceKey.m_135785_(Registries.f_268580_, new ResourceLocation("big_explosives:radiation")))), 4.0f);
+        }
+        if (Math.random() < 0.01d && (entity instanceof LivingEntity)) {
+            LivingEntity _entity3 = (LivingEntity) entity;
+            if (!_entity3.m_9236_().m_5776_()) {
+                _entity3.m_7292_(new MobEffectInstance(MobEffects.f_19604_, (int) Mth.m_216263_(RandomSource.m_216327_(), 100.0d, 200.0d), 0, false, false));
+            }
+        }
+        if (Math.random() < 0.002d && (entity instanceof LivingEntity)) {
+            LivingEntity _entity4 = (LivingEntity) entity;
+            if (!_entity4.m_9236_().m_5776_()) {
+                _entity4.m_7292_(new MobEffectInstance(MobEffects.f_19610_, (int) Mth.m_216263_(RandomSource.m_216327_(), 150.0d, 250.0d), 0, false, false));
+            }
+        }
+        if (Math.random() >= 0.005d || !(entity instanceof LivingEntity)) {
+            return;
+        }
+        LivingEntity _entity5 = (LivingEntity) entity;
+        if (!_entity5.m_9236_().m_5776_()) {
+            _entity5.m_7292_(new MobEffectInstance(MobEffects.f_19613_, (int) Mth.m_216263_(RandomSource.m_216327_(), 100.0d, 200.0d), 0, false, false));
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/ScreenShakeEffectActiveTickConditionProcedure.java
+++ b/src/main/java/com/hbm/procedures/ScreenShakeEffectActiveTickConditionProcedure.java
@@ -1,0 +1,88 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.network.BigExplosivesModVariables;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/ScreenShakeEffectActiveTickConditionProcedure.class */
+public class ScreenShakeEffectActiveTickConditionProcedure {
+    public static void execute(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double _setval = ((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake + 1.0d;
+        entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).ifPresent(capability -> {
+            capability.ScreenShake = _setval;
+            capability.syncPlayerVariables(entity);
+        });
+        if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake == 0.0d) {
+            entity.m_146922_(entity.m_146908_() + 1.0f);
+            entity.m_146926_(entity.m_146909_() + 1.0f);
+            entity.m_5618_(entity.m_146908_());
+            entity.m_5616_(entity.m_146908_());
+            entity.f_19859_ = entity.m_146908_();
+            entity.f_19860_ = entity.m_146909_();
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity = (LivingEntity) entity;
+                _entity.f_20884_ = _entity.m_146908_();
+                _entity.f_20886_ = _entity.m_146908_();
+            }
+        } else if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake == 1.0d) {
+            entity.m_146922_(entity.m_146908_() - 2.0f);
+            entity.m_146926_(entity.m_146909_() - 2.0f);
+            entity.m_5618_(entity.m_146908_());
+            entity.m_5616_(entity.m_146908_());
+            entity.f_19859_ = entity.m_146908_();
+            entity.f_19860_ = entity.m_146909_();
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity2 = (LivingEntity) entity;
+                _entity2.f_20884_ = _entity2.m_146908_();
+                _entity2.f_20886_ = _entity2.m_146908_();
+            }
+        } else if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake == 2.0d) {
+            entity.m_146922_(entity.m_146908_() + 1.0f);
+            entity.m_146926_(entity.m_146909_() + 1.0f);
+            entity.m_5618_(entity.m_146908_());
+            entity.m_5616_(entity.m_146908_());
+            entity.f_19859_ = entity.m_146908_();
+            entity.f_19860_ = entity.m_146909_();
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity3 = (LivingEntity) entity;
+                _entity3.f_20884_ = _entity3.m_146908_();
+                _entity3.f_20886_ = _entity3.m_146908_();
+            }
+        } else if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake == 3.0d) {
+            entity.m_146922_(entity.m_146908_() + 1.0f);
+            entity.m_146926_(entity.m_146909_() - 1.0f);
+            entity.m_5618_(entity.m_146908_());
+            entity.m_5616_(entity.m_146908_());
+            entity.f_19859_ = entity.m_146908_();
+            entity.f_19860_ = entity.m_146909_();
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity4 = (LivingEntity) entity;
+                _entity4.f_20884_ = _entity4.m_146908_();
+                _entity4.f_20886_ = _entity4.m_146908_();
+            }
+        } else if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake == 4.0d) {
+            entity.m_146922_(entity.m_146908_() + 0.0f);
+            entity.m_146926_(entity.m_146909_() + 1.0f);
+            entity.m_5618_(entity.m_146908_());
+            entity.m_5616_(entity.m_146908_());
+            entity.f_19859_ = entity.m_146908_();
+            entity.f_19860_ = entity.m_146909_();
+            if (entity instanceof LivingEntity) {
+                LivingEntity _entity5 = (LivingEntity) entity;
+                _entity5.f_20884_ = _entity5.m_146908_();
+                _entity5.f_20886_ = _entity5.m_146908_();
+            }
+        }
+        if (((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).ScreenShake > 4.0d) {
+            double _setval2 = 0.0d;
+            entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).ifPresent(capability2 -> {
+                capability2.ScreenShake = _setval2;
+                capability2.syncPlayerVariables(entity);
+            });
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/SetFadeProcedure.java
+++ b/src/main/java/com/hbm/procedures/SetFadeProcedure.java
@@ -1,0 +1,50 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.init.BigExplosivesModMobEffects;
+import net.mcreator.nuclearcraft.network.BigExplosivesModVariables;
+import net.minecraft.core.Direction;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/SetFadeProcedure.class */
+public class SetFadeProcedure {
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            execute(event, event.player);
+        }
+    }
+
+    public static void execute(Entity entity) {
+        execute(null, entity);
+    }
+
+    private static void execute(@Nullable Event event, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (entity instanceof LivingEntity) {
+            LivingEntity _livEnt0 = (LivingEntity) entity;
+            if (_livEnt0.m_21023_((MobEffect) BigExplosivesModMobEffects.WHITE_OUT_EFFECT.get())) {
+                double _setval = Math.min(((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).fadevariable + 0.1d, 1.0d);
+                entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).ifPresent(capability -> {
+                    capability.fadevariable = _setval;
+                    capability.syncPlayerVariables(entity);
+                });
+                return;
+            }
+        }
+        double _setval2 = Math.max(((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).fadevariable - 0.1d, 0.0d);
+        entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).ifPresent(capability2 -> {
+            capability2.fadevariable = _setval2;
+            capability2.syncPlayerVariables(entity);
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/StealCodeProcedure.java
+++ b/src/main/java/com/hbm/procedures/StealCodeProcedure.java
@@ -1,0 +1,16 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.network.BigExplosivesModVariables;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.Entity;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/StealCodeProcedure.class */
+public class StealCodeProcedure {
+    public static void execute(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        BigExplosivesMod.LOGGER.info(Double.valueOf(((BigExplosivesModVariables.PlayerVariables) entity.getCapability(BigExplosivesModVariables.PLAYER_VARIABLES_CAPABILITY, (Direction) null).orElse(new BigExplosivesModVariables.PlayerVariables())).fadevariable));
+    }
+}

--- a/src/main/java/com/hbm/procedures/SummonWhereILookProcedure.java
+++ b/src/main/java/com/hbm/procedures/SummonWhereILookProcedure.java
@@ -1,0 +1,32 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/SummonWhereILookProcedure.class */
+public class SummonWhereILookProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double Scaling = 0.0d;
+        for (int index0 = 0; index0 < 1; index0++) {
+            if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+                Scaling += 100.0d;
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_FIDDY.get()).m_262496_(_level, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + 500, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_()), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/TestOnPlayerStoppedUsingProcedure.java
+++ b/src/main/java/com/hbm/procedures/TestOnPlayerStoppedUsingProcedure.java
@@ -1,0 +1,58 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/TestOnPlayerStoppedUsingProcedure.class */
+public class TestOnPlayerStoppedUsingProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity, ItemStack itemstack) {
+        if (entity == null) {
+            return;
+        }
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f, false);
+            }
+        }
+        if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+            double Scaling2 = 0.0d + 250.0d;
+            if (world instanceof ServerLevel) {
+                Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.ATOMIC_BOMB.get()).m_262496_((ServerLevel) world, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + 400, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_()), MobSpawnType.MOB_SUMMONED);
+                if (entityToSpawn != null) {
+                    entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                }
+            }
+        }
+        BigExplosivesMod.queueServerWork(1, () -> {
+            if (itemstack.m_220157_(1, RandomSource.m_216327_(), (ServerPlayer) null)) {
+                itemstack.m_41774_(1);
+                itemstack.m_41721_(0);
+            }
+            if (entity instanceof Player) {
+                Player _player = (Player) entity;
+                _player.m_36335_().m_41524_((Item) BigExplosivesModItems.TEST.get(), 500);
+            }
+        });
+    }
+}

--- a/src/main/java/com/hbm/procedures/TestRightclickedProcedure.java
+++ b/src/main/java/com/hbm/procedures/TestRightclickedProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/TestRightclickedProcedure.class */
+public class TestRightclickedProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double Scaling = 0.0d;
+        for (int index0 = 0; index0 < 500; index0++) {
+            if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+                Scaling += 1.0d;
+            }
+            world.m_7106_(ParticleTypes.f_123748_, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_(), 0.0d, 1.0d, 0.0d);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/TwoFiddyButtonItemInInventoryTickProcedure.java
+++ b/src/main/java/com/hbm/procedures/TwoFiddyButtonItemInInventoryTickProcedure.java
@@ -1,0 +1,29 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import java.util.Map;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/TwoFiddyButtonItemInInventoryTickProcedure.class */
+public class TwoFiddyButtonItemInInventoryTickProcedure {
+    public static void execute(LevelAccessor world, ItemStack itemstack) {
+        Map<Enchantment, Integer> _enchantments = EnchantmentHelper.m_44831_(itemstack);
+        if (_enchantments.containsKey(Enchantments.f_44963_)) {
+            _enchantments.remove(Enchantments.f_44963_);
+            EnchantmentHelper.m_44865_(_enchantments, itemstack);
+        }
+        Map<Enchantment, Integer> _enchantments2 = EnchantmentHelper.m_44831_(itemstack);
+        if (_enchantments2.containsKey(Enchantments.f_44962_)) {
+            _enchantments2.remove(Enchantments.f_44962_);
+            EnchantmentHelper.m_44865_(_enchantments2, itemstack);
+        }
+        Map<Enchantment, Integer> _enchantments3 = EnchantmentHelper.m_44831_(itemstack);
+        if (_enchantments3.containsKey(Enchantments.f_44986_)) {
+            _enchantments3.remove(Enchantments.f_44986_);
+            EnchantmentHelper.m_44865_(_enchantments3, itemstack);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/TwoFiddyButtonOnPlayerStoppedUsingProcedure.java
+++ b/src/main/java/com/hbm/procedures/TwoFiddyButtonOnPlayerStoppedUsingProcedure.java
@@ -1,0 +1,96 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.init.BigExplosivesModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/TwoFiddyButtonOnPlayerStoppedUsingProcedure.class */
+public class TwoFiddyButtonOnPlayerStoppedUsingProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity, ItemStack itemstack) throws IOException {
+        if (entity == null) {
+            return;
+        }
+        double Scaling2 = 0.0d;
+        new File("");
+        new JsonObject();
+        File bigexplosives = new File(FMLPaths.GAMEDIR.get().toString() + "/config/", File.separator + "bigexplosivesconfig.json");
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new FileReader(bigexplosives));
+            StringBuilder jsonstringbuilder = new StringBuilder();
+            while (true) {
+                String line = bufferedReader.readLine();
+                if (line == null) {
+                    break;
+                } else {
+                    jsonstringbuilder.append(line);
+                }
+            }
+            bufferedReader.close();
+            JsonObject mainjsonobject = (JsonObject) new Gson().fromJson(jsonstringbuilder.toString(), JsonObject.class);
+            if (world instanceof Level) {
+                Level _level = (Level) world;
+                if (!_level.m_5776_()) {
+                    _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f);
+                } else {
+                    _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:designatorbeep")), SoundSource.NEUTRAL, 1.0f, 1.0f, false);
+                }
+            }
+            if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(0.0d)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_() && mainjsonobject.get("250kgAccurateBomb").getAsBoolean()) {
+                Scaling2 = 0.0d + 250.0d;
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level2 = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_FIDDY.get()).m_262496_(_level2, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + 400, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_()), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            }
+            for (int index0 = 0; index0 < ((int) mainjsonobject.get("250kgRandomBombAmount").getAsDouble()); index0++) {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level3 = (ServerLevel) world;
+                    Entity entityToSpawn2 = ((EntityType) BigExplosivesModEntities.TWO_FIDDY.get()).m_262496_(_level3, BlockPos.m_274561_(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_() + Mth.m_216263_(RandomSource.m_216327_(), -20.0d, 20.0d), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_() + Mth.m_216263_(RandomSource.m_216327_(), 400.0d, 500.0d), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling2)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_() + Mth.m_216263_(RandomSource.m_216327_(), -20.0d, 20.0d)), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn2 != null) {
+                        entityToSpawn2.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            }
+            BigExplosivesMod.queueServerWork(1, () -> {
+                if (itemstack.m_220157_(1, RandomSource.m_216327_(), (ServerPlayer) null)) {
+                    itemstack.m_41774_(1);
+                    itemstack.m_41721_(0);
+                }
+                if (entity instanceof Player) {
+                    Player _player = (Player) entity;
+                    _player.m_36335_().m_41524_((Item) BigExplosivesModItems.TWO_FIDDY_BUTTON.get(), 250);
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/TwoFiddyButtonRightclickedProcedure.java
+++ b/src/main/java/com/hbm/procedures/TwoFiddyButtonRightclickedProcedure.java
@@ -1,0 +1,23 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/TwoFiddyButtonRightclickedProcedure.class */
+public class TwoFiddyButtonRightclickedProcedure {
+    public static void execute(LevelAccessor world, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        double Scaling = 0.0d;
+        for (int index0 = 0; index0 < 500; index0++) {
+            if (!world.m_8055_(new BlockPos(entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_())).m_60815_()) {
+                Scaling += 1.0d;
+            }
+            world.m_7106_(ParticleTypes.f_123748_, entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123341_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123342_(), entity.m_9236_().m_45547_(new ClipContext(entity.m_20299_(1.0f), entity.m_20299_(1.0f).m_82549_(entity.m_20252_(1.0f).m_82490_(Scaling)), ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity)).m_82425_().m_123343_(), 0.0d, 1.0d, 0.0d);
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/WaterExplodeProcedure.java
+++ b/src/main/java/com/hbm/procedures/WaterExplodeProcedure.java
@@ -1,0 +1,58 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.level.LevelAccessor;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/WaterExplodeProcedure.class */
+public class WaterExplodeProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z, Entity entity) {
+        if (entity == null) {
+            return;
+        }
+        if (entity.m_5842_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268565_)), 100.0f);
+            BigExplosivesMod.queueServerWork(1, () -> {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_HUNDRED_FIFTY_KG_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y, z), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            });
+        }
+        if (entity.m_20069_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268565_)), 100.0f);
+            BigExplosivesMod.queueServerWork(1, () -> {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_HUNDRED_FIFTY_KG_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y, z), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            });
+        }
+        if (entity.m_20072_()) {
+            entity.m_6469_(new DamageSource(world.m_9598_().m_175515_(Registries.f_268580_).m_246971_(DamageTypes.f_268565_)), 100.0f);
+            BigExplosivesMod.queueServerWork(1, () -> {
+                if (world instanceof ServerLevel) {
+                    ServerLevel _level = (ServerLevel) world;
+                    Entity entityToSpawn = ((EntityType) BigExplosivesModEntities.TWO_HUNDRED_FIFTY_KG_EXPLOSION.get()).m_262496_(_level, BlockPos.m_274561_(x, y, z), MobSpawnType.MOB_SUMMONED);
+                    if (entityToSpawn != null) {
+                        entityToSpawn.m_20334_(0.0d, 0.0d, 0.0d);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/hbm/procedures/WhiteOutEffectEffectStartedappliedProcedure.java
+++ b/src/main/java/com/hbm/procedures/WhiteOutEffectEffectStartedappliedProcedure.java
@@ -1,0 +1,24 @@
+package net.mcreator.nuclearcraft.procedures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/procedures/WhiteOutEffectEffectStartedappliedProcedure.class */
+public class WhiteOutEffectEffectStartedappliedProcedure {
+    public static void execute(LevelAccessor world, double x, double y, double z) {
+        if (world instanceof Level) {
+            Level _level = (Level) world;
+            if (!_level.m_5776_()) {
+                _level.m_5594_((Player) null, BlockPos.m_274561_(x, y, z), (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:ear-ringingshort")), SoundSource.NEUTRAL, 1.0f, 1.0f);
+            } else {
+                _level.m_7785_(x, y, z, (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("big_explosives:ear-ringingshort")), SoundSource.NEUTRAL, 1.0f, 1.0f, false);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hbm/render/AtomicBombExplosionRenderer.java
+++ b/src/main/java/com/hbm/render/AtomicBombExplosionRenderer.java
@@ -1,0 +1,32 @@
+package net.mcreator.nuclearcraft.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.mcreator.nuclearcraft.entity.AtomicBombExplosionEntity;
+import net.mcreator.nuclearcraft.entity.layer.AtomicBombExplosionLayer;
+import net.mcreator.nuclearcraft.entity.model.AtomicBombExplosionModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.renderer.GeoEntityRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/renderer/AtomicBombExplosionRenderer.class */
+public class AtomicBombExplosionRenderer extends GeoEntityRenderer<AtomicBombExplosionEntity> {
+    public AtomicBombExplosionRenderer(EntityRendererProvider.Context renderManager) {
+        super(renderManager, new AtomicBombExplosionModel());
+        this.f_114477_ = 10.0f;
+        addRenderLayer(new AtomicBombExplosionLayer(this));
+    }
+
+    public RenderType getRenderType(AtomicBombExplosionEntity animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(m_5478_(animatable));
+    }
+
+    public void preRender(PoseStack poseStack, AtomicBombExplosionEntity entity, BakedGeoModel model, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        this.scaleHeight = 1.0f;
+        this.scaleWidth = 1.0f;
+        super.preRender(poseStack, entity, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+    }
+}

--- a/src/main/java/com/hbm/render/AtomicBombRenderer.java
+++ b/src/main/java/com/hbm/render/AtomicBombRenderer.java
@@ -1,0 +1,37 @@
+package net.mcreator.nuclearcraft.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.mcreator.nuclearcraft.entity.AtomicBombEntity;
+import net.mcreator.nuclearcraft.entity.layer.AtomicBombLayer;
+import net.mcreator.nuclearcraft.entity.model.AtomicBombModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.renderer.GeoEntityRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/renderer/AtomicBombRenderer.class */
+public class AtomicBombRenderer extends GeoEntityRenderer<AtomicBombEntity> {
+    public AtomicBombRenderer(EntityRendererProvider.Context renderManager) {
+        super(renderManager, new AtomicBombModel());
+        this.f_114477_ = 0.5f;
+        addRenderLayer(new AtomicBombLayer(this));
+    }
+
+    public RenderType getRenderType(AtomicBombEntity animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(m_5478_(animatable));
+    }
+
+    public void preRender(PoseStack poseStack, AtomicBombEntity entity, BakedGeoModel model, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        this.scaleHeight = 1.0f;
+        this.scaleWidth = 1.0f;
+        super.preRender(poseStack, entity, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+    }
+
+    /* JADX INFO: Access modifiers changed from: protected */
+    public float getDeathMaxRotation(AtomicBombEntity entityLivingBaseIn) {
+        return 0.0f;
+    }
+}

--- a/src/main/java/com/hbm/render/FiveBombRenderer.java
+++ b/src/main/java/com/hbm/render/FiveBombRenderer.java
@@ -1,0 +1,35 @@
+package net.mcreator.nuclearcraft.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.mcreator.nuclearcraft.entity.FiveBombEntity;
+import net.mcreator.nuclearcraft.entity.model.FiveBombModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.renderer.GeoEntityRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/renderer/FiveBombRenderer.class */
+public class FiveBombRenderer extends GeoEntityRenderer<FiveBombEntity> {
+    public FiveBombRenderer(EntityRendererProvider.Context renderManager) {
+        super(renderManager, new FiveBombModel());
+        this.f_114477_ = 0.5f;
+    }
+
+    public RenderType getRenderType(FiveBombEntity animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(m_5478_(animatable));
+    }
+
+    public void preRender(PoseStack poseStack, FiveBombEntity entity, BakedGeoModel model, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        this.scaleHeight = 1.0f;
+        this.scaleWidth = 1.0f;
+        super.preRender(poseStack, entity, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+    }
+
+    /* JADX INFO: Access modifiers changed from: protected */
+    public float getDeathMaxRotation(FiveBombEntity entityLivingBaseIn) {
+        return 0.0f;
+    }
+}

--- a/src/main/java/com/hbm/render/FiveHundredKgExplosionRenderer.java
+++ b/src/main/java/com/hbm/render/FiveHundredKgExplosionRenderer.java
@@ -1,0 +1,37 @@
+package net.mcreator.nuclearcraft.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.mcreator.nuclearcraft.entity.FiveHundredKgExplosionEntity;
+import net.mcreator.nuclearcraft.entity.layer.FiveHundredKgExplosionLayer;
+import net.mcreator.nuclearcraft.entity.model.FiveHundredKgExplosionModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.renderer.GeoEntityRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/client/renderer/FiveHundredKgExplosionRenderer.class */
+public class FiveHundredKgExplosionRenderer extends GeoEntityRenderer<FiveHundredKgExplosionEntity> {
+    public FiveHundredKgExplosionRenderer(EntityRendererProvider.Context renderManager) {
+        super(renderManager, new FiveHundredKgExplosionModel());
+        this.f_114477_ = 5.0f;
+        addRenderLayer(new FiveHundredKgExplosionLayer(this));
+    }
+
+    public RenderType getRenderType(FiveHundredKgExplosionEntity animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(m_5478_(animatable));
+    }
+
+    public void preRender(PoseStack poseStack, FiveHundredKgExplosionEntity entity, BakedGeoModel model, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        this.scaleHeight = 1.0f;
+        this.scaleWidth = 1.0f;
+        super.preRender(poseStack, entity, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, red, green, blue, alpha);
+    }
+
+    /* JADX INFO: Access modifiers changed from: protected */
+    public float getDeathMaxRotation(FiveHundredKgExplosionEntity entityLivingBaseIn) {
+        return 0.0f;
+    }
+}

--- a/src/main/java/com/hbm/render/GeckoAdvancedWorkbenchDisplayItemRenderer.java
+++ b/src/main/java/com/hbm/render/GeckoAdvancedWorkbenchDisplayItemRenderer.java
@@ -1,0 +1,19 @@
+package net.mcreator.nuclearcraft.block.renderer;
+
+import net.mcreator.nuclearcraft.block.display.GeckoAdvancedWorkbenchDisplayItem;
+import net.mcreator.nuclearcraft.block.model.GeckoAdvancedWorkbenchDisplayModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.renderer.GeoItemRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/renderer/GeckoAdvancedWorkbenchDisplayItemRenderer.class */
+public class GeckoAdvancedWorkbenchDisplayItemRenderer extends GeoItemRenderer<GeckoAdvancedWorkbenchDisplayItem> {
+    public GeckoAdvancedWorkbenchDisplayItemRenderer() {
+        super(new GeckoAdvancedWorkbenchDisplayModel());
+    }
+
+    public RenderType getRenderType(GeckoAdvancedWorkbenchDisplayItem animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(getTextureLocation(animatable));
+    }
+}

--- a/src/main/java/com/hbm/render/GeckoAdvancedWorkbenchTileRenderer.java
+++ b/src/main/java/com/hbm/render/GeckoAdvancedWorkbenchTileRenderer.java
@@ -1,0 +1,19 @@
+package net.mcreator.nuclearcraft.block.renderer;
+
+import net.mcreator.nuclearcraft.block.entity.GeckoAdvancedWorkbenchTileEntity;
+import net.mcreator.nuclearcraft.block.model.GeckoAdvancedWorkbenchBlockModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.renderer.GeoBlockRenderer;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/renderer/GeckoAdvancedWorkbenchTileRenderer.class */
+public class GeckoAdvancedWorkbenchTileRenderer extends GeoBlockRenderer<GeckoAdvancedWorkbenchTileEntity> {
+    public GeckoAdvancedWorkbenchTileRenderer() {
+        super(new GeckoAdvancedWorkbenchBlockModel());
+    }
+
+    public RenderType getRenderType(GeckoAdvancedWorkbenchTileEntity animatable, ResourceLocation texture, MultiBufferSource bufferSource, float partialTick) {
+        return RenderType.m_110473_(getTextureLocation(animatable));
+    }
+}

--- a/src/main/java/com/hbm/render/block/AdvancedWorkBenchBlockEntity.java
+++ b/src/main/java/com/hbm/render/block/AdvancedWorkBenchBlockEntity.java
@@ -1,0 +1,136 @@
+package net.mcreator.nuclearcraft.block.entity;
+
+import io.netty.buffer.Unpooled;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.init.BigExplosivesModBlockEntities;
+import net.mcreator.nuclearcraft.world.inventory.AdvancedWorkBechGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/entity/AdvancedWorkBenchBlockEntity.class */
+public class AdvancedWorkBenchBlockEntity extends RandomizableContainerBlockEntity implements WorldlyContainer {
+    private NonNullList<ItemStack> stacks;
+    private final LazyOptional<? extends IItemHandler>[] handlers;
+
+    public AdvancedWorkBenchBlockEntity(BlockPos position, BlockState state) {
+        super((BlockEntityType) BigExplosivesModBlockEntities.ADVANCED_WORK_BENCH.get(), position, state);
+        this.stacks = NonNullList.m_122780_(17, ItemStack.f_41583_);
+        this.handlers = SidedInvWrapper.create(this, Direction.values());
+    }
+
+    public void m_142466_(CompoundTag compound) {
+        super.m_142466_(compound);
+        if (!m_59631_(compound)) {
+            this.stacks = NonNullList.m_122780_(m_6643_(), ItemStack.f_41583_);
+        }
+        ContainerHelper.m_18980_(compound, this.stacks);
+    }
+
+    public void m_183515_(CompoundTag compound) {
+        super.m_183515_(compound);
+        if (!m_59634_(compound)) {
+            ContainerHelper.m_18973_(compound, this.stacks);
+        }
+    }
+
+    /* renamed from: getUpdatePacket, reason: merged with bridge method [inline-methods] */
+    public ClientboundBlockEntityDataPacket m_58483_() {
+        return ClientboundBlockEntityDataPacket.m_195640_(this);
+    }
+
+    public CompoundTag m_5995_() {
+        return m_187480_();
+    }
+
+    public int m_6643_() {
+        return this.stacks.size();
+    }
+
+    public boolean m_7983_() {
+        Iterator it = this.stacks.iterator();
+        while (it.hasNext()) {
+            ItemStack itemstack = (ItemStack) it.next();
+            if (!itemstack.m_41619_()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Component m_6820_() {
+        return Component.m_237113_("advanced_work_bench");
+    }
+
+    public int m_6893_() {
+        return 64;
+    }
+
+    public AbstractContainerMenu m_6555_(int id, Inventory inventory) {
+        return new AdvancedWorkBechGuiMenu(id, inventory, new FriendlyByteBuf(Unpooled.buffer()).m_130064_(this.f_58858_));
+    }
+
+    public Component m_5446_() {
+        return Component.m_237113_("Advanced Work bench");
+    }
+
+    protected NonNullList<ItemStack> m_7086_() {
+        return this.stacks;
+    }
+
+    protected void m_6520_(NonNullList<ItemStack> stacks) {
+        this.stacks = stacks;
+    }
+
+    public boolean m_7013_(int index, ItemStack stack) {
+        if (index == 16) {
+            return false;
+        }
+        return true;
+    }
+
+    public int[] m_7071_(Direction side) {
+        return IntStream.range(0, m_6643_()).toArray();
+    }
+
+    public boolean m_7155_(int index, ItemStack stack, @Nullable Direction direction) {
+        return m_7013_(index, stack);
+    }
+
+    public boolean m_7157_(int index, ItemStack stack, Direction direction) {
+        return true;
+    }
+
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
+        if (!this.f_58859_ && facing != null && capability == ForgeCapabilities.ITEM_HANDLER) {
+            return this.handlers[facing.ordinal()].cast();
+        }
+        return super.getCapability(capability, facing);
+    }
+
+    public void m_7651_() {
+        super.m_7651_();
+        for (LazyOptional<? extends IItemHandler> handler : this.handlers) {
+            handler.invalidate();
+        }
+    }
+}

--- a/src/main/java/com/hbm/render/block/BasicWorkBenchBlockEntity.java
+++ b/src/main/java/com/hbm/render/block/BasicWorkBenchBlockEntity.java
@@ -1,0 +1,136 @@
+package net.mcreator.nuclearcraft.block.entity;
+
+import io.netty.buffer.Unpooled;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.init.BigExplosivesModBlockEntities;
+import net.mcreator.nuclearcraft.world.inventory.BasicWorkBenchGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/entity/BasicWorkBenchBlockEntity.class */
+public class BasicWorkBenchBlockEntity extends RandomizableContainerBlockEntity implements WorldlyContainer {
+    private NonNullList<ItemStack> stacks;
+    private final LazyOptional<? extends IItemHandler>[] handlers;
+
+    public BasicWorkBenchBlockEntity(BlockPos position, BlockState state) {
+        super((BlockEntityType) BigExplosivesModBlockEntities.BASIC_WORK_BENCH.get(), position, state);
+        this.stacks = NonNullList.m_122780_(8, ItemStack.f_41583_);
+        this.handlers = SidedInvWrapper.create(this, Direction.values());
+    }
+
+    public void m_142466_(CompoundTag compound) {
+        super.m_142466_(compound);
+        if (!m_59631_(compound)) {
+            this.stacks = NonNullList.m_122780_(m_6643_(), ItemStack.f_41583_);
+        }
+        ContainerHelper.m_18980_(compound, this.stacks);
+    }
+
+    public void m_183515_(CompoundTag compound) {
+        super.m_183515_(compound);
+        if (!m_59634_(compound)) {
+            ContainerHelper.m_18973_(compound, this.stacks);
+        }
+    }
+
+    /* renamed from: getUpdatePacket, reason: merged with bridge method [inline-methods] */
+    public ClientboundBlockEntityDataPacket m_58483_() {
+        return ClientboundBlockEntityDataPacket.m_195640_(this);
+    }
+
+    public CompoundTag m_5995_() {
+        return m_187480_();
+    }
+
+    public int m_6643_() {
+        return this.stacks.size();
+    }
+
+    public boolean m_7983_() {
+        Iterator it = this.stacks.iterator();
+        while (it.hasNext()) {
+            ItemStack itemstack = (ItemStack) it.next();
+            if (!itemstack.m_41619_()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Component m_6820_() {
+        return Component.m_237113_("basic_work_bench");
+    }
+
+    public int m_6893_() {
+        return 64;
+    }
+
+    public AbstractContainerMenu m_6555_(int id, Inventory inventory) {
+        return new BasicWorkBenchGuiMenu(id, inventory, new FriendlyByteBuf(Unpooled.buffer()).m_130064_(this.f_58858_));
+    }
+
+    public Component m_5446_() {
+        return Component.m_237113_("Basic Work Bench");
+    }
+
+    protected NonNullList<ItemStack> m_7086_() {
+        return this.stacks;
+    }
+
+    protected void m_6520_(NonNullList<ItemStack> stacks) {
+        this.stacks = stacks;
+    }
+
+    public boolean m_7013_(int index, ItemStack stack) {
+        if (index == 7) {
+            return false;
+        }
+        return true;
+    }
+
+    public int[] m_7071_(Direction side) {
+        return IntStream.range(0, m_6643_()).toArray();
+    }
+
+    public boolean m_7155_(int index, ItemStack stack, @Nullable Direction direction) {
+        return m_7013_(index, stack);
+    }
+
+    public boolean m_7157_(int index, ItemStack stack, Direction direction) {
+        return true;
+    }
+
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
+        if (!this.f_58859_ && facing != null && capability == ForgeCapabilities.ITEM_HANDLER) {
+            return this.handlers[facing.ordinal()].cast();
+        }
+        return super.getCapability(capability, facing);
+    }
+
+    public void m_7651_() {
+        super.m_7651_();
+        for (LazyOptional<? extends IItemHandler> handler : this.handlers) {
+            handler.invalidate();
+        }
+    }
+}

--- a/src/main/java/com/hbm/render/block/BasicWorkBenchGeckolibTileEntity.java
+++ b/src/main/java/com/hbm/render/block/BasicWorkBenchGeckolibTileEntity.java
@@ -1,0 +1,193 @@
+package net.mcreator.nuclearcraft.block.entity;
+
+import io.netty.buffer.Unpooled;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.block.BasicWorkBenchGeckolibBlock;
+import net.mcreator.nuclearcraft.init.BigExplosivesModBlockEntities;
+import net.mcreator.nuclearcraft.world.inventory.BasicWorkBenchGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
+import software.bernie.geckolib.animatable.GeoBlockEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/entity/BasicWorkBenchGeckolibTileEntity.class */
+public class BasicWorkBenchGeckolibTileEntity extends RandomizableContainerBlockEntity implements GeoBlockEntity, WorldlyContainer {
+    private final AnimatableInstanceCache cache;
+    private NonNullList<ItemStack> stacks;
+    private final LazyOptional<? extends IItemHandler>[] handlers;
+    String prevAnim;
+
+    public BasicWorkBenchGeckolibTileEntity(BlockPos pos, BlockState state) {
+        super((BlockEntityType) BigExplosivesModBlockEntities.BASIC_WORK_BENCH_GECKOLIB.get(), pos, state);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.stacks = NonNullList.m_122780_(8, ItemStack.f_41583_);
+        this.handlers = SidedInvWrapper.create(this, Direction.values());
+        this.prevAnim = "0";
+    }
+
+    private PlayState predicate(AnimationState event) {
+        String animationprocedure = m_58900_().m_61143_(BasicWorkBenchGeckolibBlock.ANIMATION);
+        if (animationprocedure.equals("0")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop(animationprocedure));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        String animationprocedure = m_58900_().m_61143_(BasicWorkBenchGeckolibBlock.ANIMATION);
+        if ((!animationprocedure.equals("0") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!animationprocedure.equals(this.prevAnim) && !animationprocedure.equals("0"))) {
+            if (!animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                IntegerProperty integerPropertyM_61081_ = m_58900_().m_60734_().m_49965_().m_61081_("animation");
+                if (integerPropertyM_61081_ instanceof IntegerProperty) {
+                    IntegerProperty _integerProp = integerPropertyM_61081_;
+                    this.f_58857_.m_7731_(m_58899_(), (BlockState) m_58900_().m_61124_(_integerProp, 0), 3);
+                }
+                event.getController().forceAnimationReset();
+            }
+        } else if (animationprocedure.equals("0")) {
+            this.prevAnim = "0";
+            return PlayState.STOP;
+        }
+        this.prevAnim = animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "controller", 0, this::predicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedurecontroller", 0, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+
+    public void m_142466_(CompoundTag compound) {
+        super.m_142466_(compound);
+        if (!m_59631_(compound)) {
+            this.stacks = NonNullList.m_122780_(m_6643_(), ItemStack.f_41583_);
+        }
+        ContainerHelper.m_18980_(compound, this.stacks);
+    }
+
+    public void m_183515_(CompoundTag compound) {
+        super.m_183515_(compound);
+        if (!m_59634_(compound)) {
+            ContainerHelper.m_18973_(compound, this.stacks);
+        }
+    }
+
+    /* renamed from: getUpdatePacket, reason: merged with bridge method [inline-methods] */
+    public ClientboundBlockEntityDataPacket m_58483_() {
+        return ClientboundBlockEntityDataPacket.m_195640_(this);
+    }
+
+    public CompoundTag m_5995_() {
+        return m_187480_();
+    }
+
+    public int m_6643_() {
+        return this.stacks.size();
+    }
+
+    public boolean m_7983_() {
+        Iterator it = this.stacks.iterator();
+        while (it.hasNext()) {
+            ItemStack itemstack = (ItemStack) it.next();
+            if (!itemstack.m_41619_()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Component m_6820_() {
+        return Component.m_237113_("basic_work_bench_geckolib");
+    }
+
+    public int m_6893_() {
+        return 64;
+    }
+
+    public AbstractContainerMenu m_6555_(int id, Inventory inventory) {
+        return new BasicWorkBenchGuiMenu(id, inventory, new FriendlyByteBuf(Unpooled.buffer()).m_130064_(this.f_58858_));
+    }
+
+    public Component m_5446_() {
+        return Component.m_237113_("Basic Work Bench");
+    }
+
+    protected NonNullList<ItemStack> m_7086_() {
+        return this.stacks;
+    }
+
+    protected void m_6520_(NonNullList<ItemStack> stacks) {
+        this.stacks = stacks;
+    }
+
+    public boolean m_7013_(int index, ItemStack stack) {
+        if (index == 7) {
+            return false;
+        }
+        return true;
+    }
+
+    public int[] m_7071_(Direction side) {
+        return IntStream.range(0, m_6643_()).toArray();
+    }
+
+    public boolean m_7155_(int index, ItemStack stack, @Nullable Direction direction) {
+        return m_7013_(index, stack);
+    }
+
+    public boolean m_7157_(int index, ItemStack stack, Direction direction) {
+        if (index == 0 || index == 1 || index == 2 || index == 3 || index == 4 || index == 5 || index == 6) {
+            return false;
+        }
+        return true;
+    }
+
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
+        if (!this.f_58859_ && facing != null && capability == ForgeCapabilities.ITEM_HANDLER) {
+            return this.handlers[facing.ordinal()].cast();
+        }
+        return super.getCapability(capability, facing);
+    }
+
+    public void m_7651_() {
+        super.m_7651_();
+        for (LazyOptional<? extends IItemHandler> handler : this.handlers) {
+            handler.invalidate();
+        }
+    }
+}

--- a/src/main/java/com/hbm/render/block/GeckoAdvancedWorkbenchTileEntity.java
+++ b/src/main/java/com/hbm/render/block/GeckoAdvancedWorkbenchTileEntity.java
@@ -1,0 +1,190 @@
+package net.mcreator.nuclearcraft.block.entity;
+
+import io.netty.buffer.Unpooled;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.block.GeckoAdvancedWorkbenchBlock;
+import net.mcreator.nuclearcraft.init.BigExplosivesModBlockEntities;
+import net.mcreator.nuclearcraft.world.inventory.AdvancedWorkBechGuiMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.WorldlyContainer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
+import software.bernie.geckolib.animatable.GeoBlockEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/entity/GeckoAdvancedWorkbenchTileEntity.class */
+public class GeckoAdvancedWorkbenchTileEntity extends RandomizableContainerBlockEntity implements GeoBlockEntity, WorldlyContainer {
+    private final AnimatableInstanceCache cache;
+    private NonNullList<ItemStack> stacks;
+    private final LazyOptional<? extends IItemHandler>[] handlers;
+    String prevAnim;
+
+    public GeckoAdvancedWorkbenchTileEntity(BlockPos pos, BlockState state) {
+        super((BlockEntityType) BigExplosivesModBlockEntities.GECKO_ADVANCED_WORKBENCH.get(), pos, state);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.stacks = NonNullList.m_122780_(17, ItemStack.f_41583_);
+        this.handlers = SidedInvWrapper.create(this, Direction.values());
+        this.prevAnim = "0";
+    }
+
+    private PlayState predicate(AnimationState event) {
+        String animationprocedure = m_58900_().m_61143_(GeckoAdvancedWorkbenchBlock.ANIMATION);
+        if (animationprocedure.equals("0")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop(animationprocedure));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        String animationprocedure = m_58900_().m_61143_(GeckoAdvancedWorkbenchBlock.ANIMATION);
+        if ((!animationprocedure.equals("0") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!animationprocedure.equals(this.prevAnim) && !animationprocedure.equals("0"))) {
+            if (!animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                IntegerProperty integerPropertyM_61081_ = m_58900_().m_60734_().m_49965_().m_61081_("animation");
+                if (integerPropertyM_61081_ instanceof IntegerProperty) {
+                    IntegerProperty _integerProp = integerPropertyM_61081_;
+                    this.f_58857_.m_7731_(m_58899_(), (BlockState) m_58900_().m_61124_(_integerProp, 0), 3);
+                }
+                event.getController().forceAnimationReset();
+            }
+        } else if (animationprocedure.equals("0")) {
+            this.prevAnim = "0";
+            return PlayState.STOP;
+        }
+        this.prevAnim = animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "controller", 0, this::predicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedurecontroller", 0, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+
+    public void m_142466_(CompoundTag compound) {
+        super.m_142466_(compound);
+        if (!m_59631_(compound)) {
+            this.stacks = NonNullList.m_122780_(m_6643_(), ItemStack.f_41583_);
+        }
+        ContainerHelper.m_18980_(compound, this.stacks);
+    }
+
+    public void m_183515_(CompoundTag compound) {
+        super.m_183515_(compound);
+        if (!m_59634_(compound)) {
+            ContainerHelper.m_18973_(compound, this.stacks);
+        }
+    }
+
+    /* renamed from: getUpdatePacket, reason: merged with bridge method [inline-methods] */
+    public ClientboundBlockEntityDataPacket m_58483_() {
+        return ClientboundBlockEntityDataPacket.m_195640_(this);
+    }
+
+    public CompoundTag m_5995_() {
+        return m_187480_();
+    }
+
+    public int m_6643_() {
+        return this.stacks.size();
+    }
+
+    public boolean m_7983_() {
+        Iterator it = this.stacks.iterator();
+        while (it.hasNext()) {
+            ItemStack itemstack = (ItemStack) it.next();
+            if (!itemstack.m_41619_()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Component m_6820_() {
+        return Component.m_237113_("gecko_advanced_workbench");
+    }
+
+    public int m_6893_() {
+        return 64;
+    }
+
+    public AbstractContainerMenu m_6555_(int id, Inventory inventory) {
+        return new AdvancedWorkBechGuiMenu(id, inventory, new FriendlyByteBuf(Unpooled.buffer()).m_130064_(this.f_58858_));
+    }
+
+    public Component m_5446_() {
+        return Component.m_237113_("Gecko Advanced Workbench");
+    }
+
+    protected NonNullList<ItemStack> m_7086_() {
+        return this.stacks;
+    }
+
+    protected void m_6520_(NonNullList<ItemStack> stacks) {
+        this.stacks = stacks;
+    }
+
+    public boolean m_7013_(int index, ItemStack stack) {
+        if (index == 16) {
+            return false;
+        }
+        return true;
+    }
+
+    public int[] m_7071_(Direction side) {
+        return IntStream.range(0, m_6643_()).toArray();
+    }
+
+    public boolean m_7155_(int index, ItemStack stack, @Nullable Direction direction) {
+        return m_7013_(index, stack);
+    }
+
+    public boolean m_7157_(int index, ItemStack stack, Direction direction) {
+        return true;
+    }
+
+    public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
+        if (!this.f_58859_ && facing != null && capability == ForgeCapabilities.ITEM_HANDLER) {
+            return this.handlers[facing.ordinal()].cast();
+        }
+        return super.getCapability(capability, facing);
+    }
+
+    public void m_7651_() {
+        super.m_7651_();
+        for (LazyOptional<? extends IItemHandler> handler : this.handlers) {
+            handler.invalidate();
+        }
+    }
+}

--- a/src/main/java/com/hbm/render/entity/AtomicBombEntity.java
+++ b/src/main/java/com/hbm/render/entity/AtomicBombEntity.java
@@ -1,0 +1,209 @@
+package net.mcreator.nuclearcraft.entity;
+
+import java.io.IOException;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.procedures.AtomicBombDiesDuplicateProcedure;
+import net.mcreator.nuclearcraft.procedures.AtomicBombEntityFallProcedure;
+import net.mcreator.nuclearcraft.procedures.AtomicBombOnEntityTickUpdateProcedure;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.SpawnPlacements;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.goal.LookAtPlayerGoal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraftforge.network.PlayMessages;
+import net.minecraftforge.registries.ForgeRegistries;
+import software.bernie.geckolib.animatable.GeoEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/entity/AtomicBombEntity.class */
+public class AtomicBombEntity extends PathfinderMob implements GeoEntity {
+    public static final EntityDataAccessor<Boolean> SHOOT = SynchedEntityData.m_135353_(AtomicBombEntity.class, EntityDataSerializers.f_135035_);
+    public static final EntityDataAccessor<String> ANIMATION = SynchedEntityData.m_135353_(AtomicBombEntity.class, EntityDataSerializers.f_135030_);
+    public static final EntityDataAccessor<String> TEXTURE = SynchedEntityData.m_135353_(AtomicBombEntity.class, EntityDataSerializers.f_135030_);
+    private final AnimatableInstanceCache cache;
+    private boolean swinging;
+    private boolean lastloop;
+    private long lastSwing;
+    public String animationprocedure;
+    String prevAnim;
+
+    public AtomicBombEntity(PlayMessages.SpawnEntity packet, Level world) {
+        this((EntityType<AtomicBombEntity>) BigExplosivesModEntities.ATOMIC_BOMB.get(), world);
+    }
+
+    public AtomicBombEntity(EntityType<AtomicBombEntity> type, Level world) {
+        super(type, world);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.animationprocedure = "empty";
+        this.prevAnim = "empty";
+        this.f_21364_ = 0;
+        m_21557_(false);
+        m_274367_(0.0f);
+        m_21530_();
+    }
+
+    protected void m_8097_() {
+        super.m_8097_();
+        this.f_19804_.m_135372_(SHOOT, false);
+        this.f_19804_.m_135372_(ANIMATION, "undefined");
+        this.f_19804_.m_135372_(TEXTURE, "atomicbomb");
+    }
+
+    public void setTexture(String texture) {
+        this.f_19804_.m_135381_(TEXTURE, texture);
+    }
+
+    public String getTexture() {
+        return (String) this.f_19804_.m_135370_(TEXTURE);
+    }
+
+    public Packet<ClientGamePacketListener> m_5654_() {
+        return NetworkHooks.getEntitySpawningPacket(this);
+    }
+
+    protected void m_8099_() {
+        super.m_8099_();
+        this.f_21345_.m_25352_(1, new LookAtPlayerGoal(this, Player.class, 6.0f));
+        this.f_21345_.m_25352_(2, new LookAtPlayerGoal(this, ServerPlayer.class, 6.0f));
+    }
+
+    public MobType m_6336_() {
+        return MobType.f_21640_;
+    }
+
+    public boolean m_6785_(double distanceToClosestPlayer) {
+        return false;
+    }
+
+    public SoundEvent m_7975_(DamageSource ds) {
+        return (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("intentionally_empty"));
+    }
+
+    public SoundEvent m_5592_() {
+        return (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("intentionally_empty"));
+    }
+
+    public boolean m_142535_(float l, float d, DamageSource source) {
+        AtomicBombEntityFallProcedure.execute(m_9236_(), this);
+        return super.m_142535_(l, d, source);
+    }
+
+    public void m_6667_(DamageSource source) throws IOException {
+        super.m_6667_(source);
+        AtomicBombDiesDuplicateProcedure.execute(m_9236_(), m_20185_(), m_20186_(), m_20189_(), this);
+    }
+
+    public void m_7380_(CompoundTag compound) {
+        super.m_7380_(compound);
+        compound.m_128359_("Texture", getTexture());
+    }
+
+    public void m_7378_(CompoundTag compound) {
+        super.m_7378_(compound);
+        if (compound.m_128441_("Texture")) {
+            setTexture(compound.m_128461_("Texture"));
+        }
+    }
+
+    public void m_6075_() {
+        super.m_6075_();
+        AtomicBombOnEntityTickUpdateProcedure.execute(m_9236_(), this);
+        m_6210_();
+    }
+
+    public EntityDimensions m_6972_(Pose p_33597_) {
+        return super.m_6972_(p_33597_).m_20388_(1.0f);
+    }
+
+    public void m_8107_() {
+        super.m_8107_();
+        m_21203_();
+    }
+
+    public static void init() {
+        SpawnPlacements.m_21754_((EntityType) BigExplosivesModEntities.ATOMIC_BOMB.get(), SpawnPlacements.Type.NO_RESTRICTIONS, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, (v0, v1, v2, v3, v4) -> {
+            return Mob.m_217057_(v0, v1, v2, v3, v4);
+        });
+    }
+
+    public static AttributeSupplier.Builder createAttributes() {
+        AttributeSupplier.Builder builder = Mob.m_21552_();
+        return builder.m_22268_(Attributes.f_22279_, 0.0d).m_22268_(Attributes.f_22276_, 10.0d).m_22268_(Attributes.f_22284_, 0.0d).m_22268_(Attributes.f_22281_, 3.0d).m_22268_(Attributes.f_22277_, 16.0d);
+    }
+
+    private PlayState movementPredicate(AnimationState event) {
+        if (this.animationprocedure.equals("empty")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop("AtomicBomb.model.new "));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        if ((!this.animationprocedure.equals("empty") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!this.animationprocedure.equals(this.prevAnim) && !this.animationprocedure.equals("empty"))) {
+            if (!this.animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(this.animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                this.animationprocedure = "empty";
+                event.getController().forceAnimationReset();
+            }
+        } else if (this.animationprocedure.equals("empty")) {
+            this.prevAnim = "empty";
+            return PlayState.STOP;
+        }
+        this.prevAnim = this.animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    protected void m_6153_() {
+        this.f_20919_++;
+        if (this.f_20919_ == 1) {
+            m_142687_(Entity.RemovalReason.KILLED);
+            m_21226_();
+        }
+    }
+
+    public String getSyncedAnimation() {
+        return (String) this.f_19804_.m_135370_(ANIMATION);
+    }
+
+    public void setAnimation(String animation) {
+        this.f_19804_.m_135381_(ANIMATION, animation);
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "movement", 4, this::movementPredicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedure", 4, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+}

--- a/src/main/java/com/hbm/render/entity/AtomicBombExplosionEntity.java
+++ b/src/main/java/com/hbm/render/entity/AtomicBombExplosionEntity.java
@@ -1,0 +1,230 @@
+package net.mcreator.nuclearcraft.entity;
+
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.procedures.AtomicBombExplosionOnEntityTickUpdateProcedure;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.AreaEffectCloud;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.SpawnGroupData;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.control.FlyingMoveControl;
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.entity.projectile.ThrownPotion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraftforge.network.PlayMessages;
+import software.bernie.geckolib.animatable.GeoEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/entity/AtomicBombExplosionEntity.class */
+public class AtomicBombExplosionEntity extends PathfinderMob implements GeoEntity {
+    public static final EntityDataAccessor<Boolean> SHOOT = SynchedEntityData.m_135353_(AtomicBombExplosionEntity.class, EntityDataSerializers.f_135035_);
+    public static final EntityDataAccessor<String> ANIMATION = SynchedEntityData.m_135353_(AtomicBombExplosionEntity.class, EntityDataSerializers.f_135030_);
+    public static final EntityDataAccessor<String> TEXTURE = SynchedEntityData.m_135353_(AtomicBombExplosionEntity.class, EntityDataSerializers.f_135030_);
+    private final AnimatableInstanceCache cache;
+    private boolean swinging;
+    private boolean lastloop;
+    private long lastSwing;
+    public String animationprocedure;
+    String prevAnim;
+
+    public AtomicBombExplosionEntity(PlayMessages.SpawnEntity packet, Level world) {
+        this((EntityType<AtomicBombExplosionEntity>) BigExplosivesModEntities.ATOMIC_BOMB_EXPLOSION.get(), world);
+    }
+
+    public AtomicBombExplosionEntity(EntityType<AtomicBombExplosionEntity> type, Level world) {
+        super(type, world);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.animationprocedure = "empty";
+        this.prevAnim = "empty";
+        this.f_21364_ = 0;
+        m_21557_(false);
+        m_274367_(0.6f);
+        m_21530_();
+        this.f_21342_ = new FlyingMoveControl(this, 10, true);
+    }
+
+    protected void m_8097_() {
+        super.m_8097_();
+        this.f_19804_.m_135372_(SHOOT, false);
+        this.f_19804_.m_135372_(ANIMATION, "undefined");
+        this.f_19804_.m_135372_(TEXTURE, "atomicbombtexture");
+    }
+
+    public void setTexture(String texture) {
+        this.f_19804_.m_135381_(TEXTURE, texture);
+    }
+
+    public String getTexture() {
+        return (String) this.f_19804_.m_135370_(TEXTURE);
+    }
+
+    public Packet<ClientGamePacketListener> m_5654_() {
+        return NetworkHooks.getEntitySpawningPacket(this);
+    }
+
+    protected PathNavigation m_6037_(Level world) {
+        return new FlyingPathNavigation(this, world);
+    }
+
+    protected void m_8099_() {
+        super.m_8099_();
+    }
+
+    public MobType m_6336_() {
+        return MobType.f_21640_;
+    }
+
+    public boolean m_6785_(double distanceToClosestPlayer) {
+        return false;
+    }
+
+    public boolean m_142535_(float l, float d, DamageSource source) {
+        return false;
+    }
+
+    public boolean m_6469_(DamageSource source, float amount) {
+        if (source.m_276093_(DamageTypes.f_268631_) || (source.m_7640_() instanceof AbstractArrow) || (source.m_7640_() instanceof Player) || (source.m_7640_() instanceof ThrownPotion) || (source.m_7640_() instanceof AreaEffectCloud) || source.m_276093_(DamageTypes.f_268671_) || source.m_276093_(DamageTypes.f_268585_) || source.m_276093_(DamageTypes.f_268722_) || source.m_276093_(DamageTypes.f_268450_) || source.m_276093_(DamageTypes.f_268565_) || source.m_276093_(DamageTypes.f_268714_) || source.m_276093_(DamageTypes.f_268526_) || source.m_276093_(DamageTypes.f_268482_) || source.m_276093_(DamageTypes.f_268493_) || source.m_276093_(DamageTypes.f_268641_)) {
+            return false;
+        }
+        return super.m_6469_(source, amount);
+    }
+
+    public SpawnGroupData m_6518_(ServerLevelAccessor world, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData livingdata, @Nullable CompoundTag tag) {
+        SpawnGroupData retval = super.m_6518_(world, difficulty, reason, livingdata, tag);
+        AtomicBombExplosionOnEntityTickUpdateProcedure.execute(world, this);
+        return retval;
+    }
+
+    public void m_7380_(CompoundTag compound) {
+        super.m_7380_(compound);
+        compound.m_128359_("Texture", getTexture());
+    }
+
+    public void m_7378_(CompoundTag compound) {
+        super.m_7378_(compound);
+        if (compound.m_128441_("Texture")) {
+            setTexture(compound.m_128461_("Texture"));
+        }
+    }
+
+    public void m_6075_() {
+        super.m_6075_();
+        AtomicBombExplosionOnEntityTickUpdateProcedure.execute(m_9236_(), this);
+        m_6210_();
+    }
+
+    public EntityDimensions m_6972_(Pose p_33597_) {
+        return super.m_6972_(p_33597_).m_20388_(1.0f);
+    }
+
+    public boolean m_6094_() {
+        return false;
+    }
+
+    protected void m_7324_(Entity entityIn) {
+    }
+
+    protected void m_6138_() {
+    }
+
+    protected void m_7840_(double y, boolean onGroundIn, BlockState state, BlockPos pos) {
+    }
+
+    public void m_20242_(boolean ignored) {
+        super.m_20242_(true);
+    }
+
+    public void m_8107_() {
+        super.m_8107_();
+        m_21203_();
+        m_20242_(true);
+    }
+
+    public static void init() {
+    }
+
+    public static AttributeSupplier.Builder createAttributes() {
+        AttributeSupplier.Builder builder = Mob.m_21552_();
+        return builder.m_22268_(Attributes.f_22279_, 0.5d).m_22268_(Attributes.f_22276_, 1000.0d).m_22268_(Attributes.f_22284_, 0.0d).m_22268_(Attributes.f_22281_, 3.0d).m_22268_(Attributes.f_22277_, 16.0d).m_22268_(Attributes.f_22280_, 0.5d);
+    }
+
+    private PlayState movementPredicate(AnimationState event) {
+        if (this.animationprocedure.equals("empty")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop("AtomicBombExplosion.model.new"));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        if ((!this.animationprocedure.equals("empty") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!this.animationprocedure.equals(this.prevAnim) && !this.animationprocedure.equals("empty"))) {
+            if (!this.animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(this.animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                this.animationprocedure = "empty";
+                event.getController().forceAnimationReset();
+            }
+        } else if (this.animationprocedure.equals("empty")) {
+            this.prevAnim = "empty";
+            return PlayState.STOP;
+        }
+        this.prevAnim = this.animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    protected void m_6153_() {
+        this.f_20919_++;
+        if (this.f_20919_ == 20) {
+            m_142687_(Entity.RemovalReason.KILLED);
+            m_21226_();
+        }
+    }
+
+    public String getSyncedAnimation() {
+        return (String) this.f_19804_.m_135370_(ANIMATION);
+    }
+
+    public void setAnimation(String animation) {
+        this.f_19804_.m_135381_(ANIMATION, animation);
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "movement", 4, this::movementPredicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedure", 4, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+}

--- a/src/main/java/com/hbm/render/entity/FiveBombEntity.java
+++ b/src/main/java/com/hbm/render/entity/FiveBombEntity.java
@@ -1,0 +1,188 @@
+package net.mcreator.nuclearcraft.entity;
+
+import java.io.IOException;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.procedures.FiveBombEntityDiesProcedure;
+import net.mcreator.nuclearcraft.procedures.FiveBombWaterExplodeProcedure;
+import net.mcreator.nuclearcraft.procedures.FiveHundredKgBombEntityDiesProcedure;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraftforge.network.PlayMessages;
+import software.bernie.geckolib.animatable.GeoEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/entity/FiveBombEntity.class */
+public class FiveBombEntity extends PathfinderMob implements GeoEntity {
+    public static final EntityDataAccessor<Boolean> SHOOT = SynchedEntityData.m_135353_(FiveBombEntity.class, EntityDataSerializers.f_135035_);
+    public static final EntityDataAccessor<String> ANIMATION = SynchedEntityData.m_135353_(FiveBombEntity.class, EntityDataSerializers.f_135030_);
+    public static final EntityDataAccessor<String> TEXTURE = SynchedEntityData.m_135353_(FiveBombEntity.class, EntityDataSerializers.f_135030_);
+    private final AnimatableInstanceCache cache;
+    private boolean swinging;
+    private boolean lastloop;
+    private long lastSwing;
+    public String animationprocedure;
+    String prevAnim;
+
+    public FiveBombEntity(PlayMessages.SpawnEntity packet, Level world) {
+        this((EntityType<FiveBombEntity>) BigExplosivesModEntities.FIVE_BOMB.get(), world);
+    }
+
+    public FiveBombEntity(EntityType<FiveBombEntity> type, Level world) {
+        super(type, world);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.animationprocedure = "empty";
+        this.prevAnim = "empty";
+        this.f_21364_ = 0;
+        m_21557_(false);
+        m_274367_(0.6f);
+        m_21530_();
+    }
+
+    protected void m_8097_() {
+        super.m_8097_();
+        this.f_19804_.m_135372_(SHOOT, false);
+        this.f_19804_.m_135372_(ANIMATION, "undefined");
+        this.f_19804_.m_135372_(TEXTURE, "500kg");
+    }
+
+    public void setTexture(String texture) {
+        this.f_19804_.m_135381_(TEXTURE, texture);
+    }
+
+    public String getTexture() {
+        return (String) this.f_19804_.m_135370_(TEXTURE);
+    }
+
+    public Packet<ClientGamePacketListener> m_5654_() {
+        return NetworkHooks.getEntitySpawningPacket(this);
+    }
+
+    protected void m_8099_() {
+        super.m_8099_();
+    }
+
+    public MobType m_6336_() {
+        return MobType.f_21640_;
+    }
+
+    public boolean m_6785_(double distanceToClosestPlayer) {
+        return false;
+    }
+
+    public boolean m_142535_(float l, float d, DamageSource source) throws IOException {
+        FiveHundredKgBombEntityDiesProcedure.execute(m_9236_(), m_20185_(), m_20186_(), m_20189_());
+        return super.m_142535_(l, d, source);
+    }
+
+    public void m_6667_(DamageSource source) {
+        super.m_6667_(source);
+        FiveBombEntityDiesProcedure.execute(m_9236_(), m_20185_(), m_20186_(), m_20189_());
+    }
+
+    public void m_7380_(CompoundTag compound) {
+        super.m_7380_(compound);
+        compound.m_128359_("Texture", getTexture());
+    }
+
+    public void m_7378_(CompoundTag compound) {
+        super.m_7378_(compound);
+        if (compound.m_128441_("Texture")) {
+            setTexture(compound.m_128461_("Texture"));
+        }
+    }
+
+    public void m_6075_() {
+        super.m_6075_();
+        FiveBombWaterExplodeProcedure.execute(m_9236_(), m_20185_(), m_20186_(), m_20189_(), this);
+        m_6210_();
+    }
+
+    public EntityDimensions m_6972_(Pose p_33597_) {
+        return super.m_6972_(p_33597_).m_20388_(1.0f);
+    }
+
+    public void m_8107_() {
+        super.m_8107_();
+        m_21203_();
+    }
+
+    public static void init() {
+    }
+
+    public static AttributeSupplier.Builder createAttributes() {
+        AttributeSupplier.Builder builder = Mob.m_21552_();
+        return builder.m_22268_(Attributes.f_22279_, 0.0d).m_22268_(Attributes.f_22276_, 10.0d).m_22268_(Attributes.f_22284_, 0.0d).m_22268_(Attributes.f_22281_, 3.0d).m_22268_(Attributes.f_22277_, 16.0d);
+    }
+
+    private PlayState movementPredicate(AnimationState event) {
+        if (this.animationprocedure.equals("empty")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop("500kg.model.new"));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        if ((!this.animationprocedure.equals("empty") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!this.animationprocedure.equals(this.prevAnim) && !this.animationprocedure.equals("empty"))) {
+            if (!this.animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(this.animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                this.animationprocedure = "empty";
+                event.getController().forceAnimationReset();
+            }
+        } else if (this.animationprocedure.equals("empty")) {
+            this.prevAnim = "empty";
+            return PlayState.STOP;
+        }
+        this.prevAnim = this.animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    protected void m_6153_() {
+        this.f_20919_++;
+        if (this.f_20919_ == 1) {
+            m_142687_(Entity.RemovalReason.KILLED);
+            m_21226_();
+        }
+    }
+
+    public String getSyncedAnimation() {
+        return (String) this.f_19804_.m_135370_(ANIMATION);
+    }
+
+    public void setAnimation(String animation) {
+        this.f_19804_.m_135381_(ANIMATION, animation);
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "movement", 4, this::movementPredicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedure", 4, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+}

--- a/src/main/java/com/hbm/render/entity/FiveHundredKgExplosionEntity.java
+++ b/src/main/java/com/hbm/render/entity/FiveHundredKgExplosionEntity.java
@@ -1,0 +1,237 @@
+package net.mcreator.nuclearcraft.entity;
+
+import javax.annotation.Nullable;
+import net.mcreator.nuclearcraft.init.BigExplosivesModEntities;
+import net.mcreator.nuclearcraft.procedures.FiveHundredKgExplosionOnEntityTickUpdateProcedure;
+import net.mcreator.nuclearcraft.procedures.FiveHundredKgExplosionOnInitialEntitySpawnProcedure;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.AreaEffectCloud;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.SpawnGroupData;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.control.FlyingMoveControl;
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.entity.projectile.ThrownPotion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.network.NetworkHooks;
+import net.minecraftforge.network.PlayMessages;
+import net.minecraftforge.registries.ForgeRegistries;
+import software.bernie.geckolib.animatable.GeoEntity;
+import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
+import software.bernie.geckolib.util.GeckoLibUtil;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/entity/FiveHundredKgExplosionEntity.class */
+public class FiveHundredKgExplosionEntity extends PathfinderMob implements GeoEntity {
+    public static final EntityDataAccessor<Boolean> SHOOT = SynchedEntityData.m_135353_(FiveHundredKgExplosionEntity.class, EntityDataSerializers.f_135035_);
+    public static final EntityDataAccessor<String> ANIMATION = SynchedEntityData.m_135353_(FiveHundredKgExplosionEntity.class, EntityDataSerializers.f_135030_);
+    public static final EntityDataAccessor<String> TEXTURE = SynchedEntityData.m_135353_(FiveHundredKgExplosionEntity.class, EntityDataSerializers.f_135030_);
+    private final AnimatableInstanceCache cache;
+    private boolean swinging;
+    private boolean lastloop;
+    private long lastSwing;
+    public String animationprocedure;
+    String prevAnim;
+
+    public FiveHundredKgExplosionEntity(PlayMessages.SpawnEntity packet, Level world) {
+        this((EntityType<FiveHundredKgExplosionEntity>) BigExplosivesModEntities.FIVE_HUNDRED_KG_EXPLOSION.get(), world);
+    }
+
+    public FiveHundredKgExplosionEntity(EntityType<FiveHundredKgExplosionEntity> type, Level world) {
+        super(type, world);
+        this.cache = GeckoLibUtil.createInstanceCache(this);
+        this.animationprocedure = "empty";
+        this.prevAnim = "empty";
+        this.f_21364_ = 0;
+        m_21557_(false);
+        m_274367_(0.6f);
+        this.f_21342_ = new FlyingMoveControl(this, 10, true);
+    }
+
+    protected void m_8097_() {
+        super.m_8097_();
+        this.f_19804_.m_135372_(SHOOT, false);
+        this.f_19804_.m_135372_(ANIMATION, "undefined");
+        this.f_19804_.m_135372_(TEXTURE, "500kgtexture");
+    }
+
+    public void setTexture(String texture) {
+        this.f_19804_.m_135381_(TEXTURE, texture);
+    }
+
+    public String getTexture() {
+        return (String) this.f_19804_.m_135370_(TEXTURE);
+    }
+
+    public Packet<ClientGamePacketListener> m_5654_() {
+        return NetworkHooks.getEntitySpawningPacket(this);
+    }
+
+    protected PathNavigation m_6037_(Level world) {
+        return new FlyingPathNavigation(this, world);
+    }
+
+    protected void m_8099_() {
+        super.m_8099_();
+    }
+
+    public MobType m_6336_() {
+        return MobType.f_21640_;
+    }
+
+    public SoundEvent m_7975_(DamageSource ds) {
+        return (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.generic.hurt"));
+    }
+
+    public SoundEvent m_5592_() {
+        return (SoundEvent) ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.generic.death"));
+    }
+
+    public boolean m_142535_(float l, float d, DamageSource source) {
+        return false;
+    }
+
+    public boolean m_6469_(DamageSource source, float amount) {
+        if (source.m_276093_(DamageTypes.f_268631_) || (source.m_7640_() instanceof AbstractArrow) || (source.m_7640_() instanceof Player) || (source.m_7640_() instanceof ThrownPotion) || (source.m_7640_() instanceof AreaEffectCloud) || source.m_276093_(DamageTypes.f_268671_) || source.m_276093_(DamageTypes.f_268585_) || source.m_276093_(DamageTypes.f_268722_) || source.m_276093_(DamageTypes.f_268450_) || source.m_276093_(DamageTypes.f_268565_) || source.m_276093_(DamageTypes.f_268714_) || source.m_276093_(DamageTypes.f_268526_) || source.m_276093_(DamageTypes.f_268482_) || source.m_276093_(DamageTypes.f_268493_) || source.m_276093_(DamageTypes.f_268641_)) {
+            return false;
+        }
+        return super.m_6469_(source, amount);
+    }
+
+    public SpawnGroupData m_6518_(ServerLevelAccessor world, DifficultyInstance difficulty, MobSpawnType reason, @Nullable SpawnGroupData livingdata, @Nullable CompoundTag tag) {
+        SpawnGroupData retval = super.m_6518_(world, difficulty, reason, livingdata, tag);
+        FiveHundredKgExplosionOnEntityTickUpdateProcedure.execute(world, m_20185_(), m_20186_(), m_20189_());
+        return retval;
+    }
+
+    public void m_7380_(CompoundTag compound) {
+        super.m_7380_(compound);
+        compound.m_128359_("Texture", getTexture());
+    }
+
+    public void m_7378_(CompoundTag compound) {
+        super.m_7378_(compound);
+        if (compound.m_128441_("Texture")) {
+            setTexture(compound.m_128461_("Texture"));
+        }
+    }
+
+    public void m_6075_() {
+        super.m_6075_();
+        FiveHundredKgExplosionOnInitialEntitySpawnProcedure.execute(m_9236_(), this);
+        m_6210_();
+    }
+
+    public EntityDimensions m_6972_(Pose p_33597_) {
+        return super.m_6972_(p_33597_).m_20388_(1.0f);
+    }
+
+    public boolean m_6094_() {
+        return false;
+    }
+
+    protected void m_7324_(Entity entityIn) {
+    }
+
+    protected void m_6138_() {
+    }
+
+    protected void m_7840_(double y, boolean onGroundIn, BlockState state, BlockPos pos) {
+    }
+
+    public void m_20242_(boolean ignored) {
+        super.m_20242_(true);
+    }
+
+    public void m_8107_() {
+        super.m_8107_();
+        m_21203_();
+        m_20242_(true);
+    }
+
+    public static void init() {
+    }
+
+    public static AttributeSupplier.Builder createAttributes() {
+        AttributeSupplier.Builder builder = Mob.m_21552_();
+        return builder.m_22268_(Attributes.f_22279_, 0.3d).m_22268_(Attributes.f_22276_, 1000.0d).m_22268_(Attributes.f_22284_, 0.0d).m_22268_(Attributes.f_22281_, 3.0d).m_22268_(Attributes.f_22277_, 16.0d).m_22268_(Attributes.f_22278_, 0.5d).m_22268_(Attributes.f_22280_, 0.3d);
+    }
+
+    private PlayState movementPredicate(AnimationState event) {
+        if (this.animationprocedure.equals("empty")) {
+            return event.setAndContinue(RawAnimation.begin().thenLoop("mediumexplosion.model.new"));
+        }
+        return PlayState.STOP;
+    }
+
+    private PlayState procedurePredicate(AnimationState event) {
+        if ((!this.animationprocedure.equals("empty") && event.getController().getAnimationState() == AnimationController.State.STOPPED) || (!this.animationprocedure.equals(this.prevAnim) && !this.animationprocedure.equals("empty"))) {
+            if (!this.animationprocedure.equals(this.prevAnim)) {
+                event.getController().forceAnimationReset();
+            }
+            event.getController().setAnimation(RawAnimation.begin().thenPlay(this.animationprocedure));
+            if (event.getController().getAnimationState() == AnimationController.State.STOPPED) {
+                this.animationprocedure = "empty";
+                event.getController().forceAnimationReset();
+            }
+        } else if (this.animationprocedure.equals("empty")) {
+            this.prevAnim = "empty";
+            return PlayState.STOP;
+        }
+        this.prevAnim = this.animationprocedure;
+        return PlayState.CONTINUE;
+    }
+
+    protected void m_6153_() {
+        this.f_20919_++;
+        if (this.f_20919_ == 1) {
+            m_142687_(Entity.RemovalReason.KILLED);
+            m_21226_();
+        }
+    }
+
+    public String getSyncedAnimation() {
+        return (String) this.f_19804_.m_135370_(ANIMATION);
+    }
+
+    public void setAnimation(String animation) {
+        this.f_19804_.m_135381_(ANIMATION, animation);
+    }
+
+    public void registerControllers(AnimatableManager.ControllerRegistrar data) {
+        data.add(new AnimationController[]{new AnimationController(this, "movement", 4, this::movementPredicate)});
+        data.add(new AnimationController[]{new AnimationController(this, "procedure", 4, this::procedurePredicate)});
+    }
+
+    public AnimatableInstanceCache getAnimatableInstanceCache() {
+        return this.cache;
+    }
+}

--- a/src/main/java/com/hbm/render/model/GeckoAdvancedWorkbenchBlockModel.java
+++ b/src/main/java/com/hbm/render/model/GeckoAdvancedWorkbenchBlockModel.java
@@ -1,0 +1,21 @@
+package net.mcreator.nuclearcraft.block.model;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.block.entity.GeckoAdvancedWorkbenchTileEntity;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.model.GeoModel;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/model/GeckoAdvancedWorkbenchBlockModel.class */
+public class GeckoAdvancedWorkbenchBlockModel extends GeoModel<GeckoAdvancedWorkbenchTileEntity> {
+    public ResourceLocation getAnimationResource(GeckoAdvancedWorkbenchTileEntity animatable) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "animations/advancedworkbench_1.animation.json");
+    }
+
+    public ResourceLocation getModelResource(GeckoAdvancedWorkbenchTileEntity animatable) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "geo/advancedworkbench_1.geo.json");
+    }
+
+    public ResourceLocation getTextureResource(GeckoAdvancedWorkbenchTileEntity animatable) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "textures/block/texture.png");
+    }
+}

--- a/src/main/java/com/hbm/render/model/GeckoAdvancedWorkbenchDisplayModel.java
+++ b/src/main/java/com/hbm/render/model/GeckoAdvancedWorkbenchDisplayModel.java
@@ -1,0 +1,21 @@
+package net.mcreator.nuclearcraft.block.model;
+
+import net.mcreator.nuclearcraft.BigExplosivesMod;
+import net.mcreator.nuclearcraft.block.display.GeckoAdvancedWorkbenchDisplayItem;
+import net.minecraft.resources.ResourceLocation;
+import software.bernie.geckolib.model.GeoModel;
+
+/* loaded from: explosives_beta.jar:net/mcreator/nuclearcraft/block/model/GeckoAdvancedWorkbenchDisplayModel.class */
+public class GeckoAdvancedWorkbenchDisplayModel extends GeoModel<GeckoAdvancedWorkbenchDisplayItem> {
+    public ResourceLocation getAnimationResource(GeckoAdvancedWorkbenchDisplayItem animatable) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "animations/advancedworkbench_1.animation.json");
+    }
+
+    public ResourceLocation getModelResource(GeckoAdvancedWorkbenchDisplayItem animatable) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "geo/advancedworkbench_1.geo.json");
+    }
+
+    public ResourceLocation getTextureResource(GeckoAdvancedWorkbenchDisplayItem entity) {
+        return new ResourceLocation(BigExplosivesMod.MODID, "textures/block/texture.png");
+    }
+}


### PR DESCRIPTION
# 请注意：这次的PR并非直接开箱即用。搬运和实现需要大量的后期处理，目前仍处于搬运、优化、开发状态，可兼容Mac和部份类Unix系统。

## 🚧 当前开发进度：51%
🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜ (51%)

# ✨ 新增功能：核爆与 GeckoLib 特效系统集成

## 🧩 概述
本次pr实现了 **蘑菇云/核爆特效** 以及相关的 **视觉与听觉反馈系统**，并集成了 GeckoLib 动画框架以支持复杂的实体与方块动画逻辑。

提交摘要：
> `加入蘑菇云/核爆以及瞬间白屏燃烧和耳鸣特效, 并加入主要的 GeckoLib 类与函数 (自开发及搬运)`

共修改 **78 个文件**，新增约 **5159 行代码**。

---

## 🌋 主要更新内容

### 🔥 视觉与物理特效
- **核爆场景实现：**
  - 添加蘑菇云粒子与爆炸体积计算；
  - 实现瞬间白屏、灼烧感、视野模糊与震动效果；
  - 新增烟雾粒子 `SmokeParticle` 与屏幕震动状态效果 `ScreenShakeEffectMobEffect`。

- **听觉特效：**
  - 引入耳鸣效果 `WhiteOutEffectMobEffect`；
  - 添加辐射中毒与免疫状态（`RadiationPoisoningMobEffect` / `RadiationImmunityMobEffect`）。

### 🧠 动画系统与 GeckoLib 集成
- 新增 GeckoLib 动画类与渲染接口，包括：
  - `EntityAnimationFactory`
  - `GeckoAdvancedWorkbenchTileEntity`
  - `GeckoAdvancedWorkbenchDisplayItemRenderer`
  - 对应的模型类与渲染器（`GeckoAdvancedWorkbenchBlockModel` 等）。

- 支持动态渲染与动画绑定，便于后续自定义爆炸与设备动画。

### ⚙️ 程序与网络逻辑
- 新增多种 Procedure 逻辑函数，用于核爆、掉落、方块交互与 GUI 交互。
- 扩展网络交互消息：
  - `AdvancedWorkBenchGuiSlotMessage`
  - `BigExplosivesModVariables` 等。

---

## 🧪 影响范围
- 模块：`com.hbm.init`, `com.hbm.render`, `com.hbm.procedures`, `com.hbm.potion`, `com.hbm.network`
- 新增 10+ 个核心类文件夹与数十个新渲染类。
- 对接 `BigExplosivesMod` 系列类，扩展未来大型爆炸机制。

---

## 📦 未来计划
- [ ] 调整爆炸伤害算法与粒子渲染性能；
- [ ] 引入地形破坏与辐射残留机制；
- [ ] 增强 GeckoLib 动画表现与多阶段爆炸逻辑；
- [ ] 对接音效同步系统。

---

## 🧰 兼容性
- 基于分支：`feature/NuclearEffectAndGecko`
- 合并目标：`test1.20.1`
- 兼容 Minecraft 1.20.1（Forge 版），依赖 GeckoLib。

---

## 注
此次更新包括部分自研与搬运整合的 GeckoLib功能。但仍然需要下载GeckoLib。